### PR TITLE
fix: use absolute path for dotenv config loading

### DIFF
--- a/scripts/send.js
+++ b/scripts/send.js
@@ -12,7 +12,10 @@
  *   1 - Error
  */
 
-import 'dotenv/config';
+import dotenv from 'dotenv';
+import path from 'path';
+dotenv.config({ path: path.join(process.env.HOME, 'zylos/.env') });
+
 import { getConfig } from '../src/lib/config.js';
 import { sendToGroup, uploadImage, sendImage, uploadFile, sendFile } from '../src/lib/message.js';
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -3,7 +3,10 @@
  * Lark CLI - Command line interface for Lark/Feishu API
  */
 
-import 'dotenv/config';
+import dotenv from 'dotenv';
+import path from 'path';
+dotenv.config({ path: path.join(process.env.HOME, 'zylos/.env') });
+
 import { testAuth } from './lib/client.js';
 import { sendToGroup, sendToUser, listMessages, uploadImage, sendImage, uploadFile, sendFile, downloadImage } from './lib/message.js';
 import { getDocument, getDocumentInfo, getWikiNode, getSpreadsheet, getSheetValues, writeSheetValues, copySheet, addSheet } from './lib/document.js';

--- a/src/index.js
+++ b/src/index.js
@@ -5,12 +5,15 @@
  * Webhook server for receiving Lark messages and routing to Claude.
  */
 
-import 'dotenv/config';
+import dotenv from 'dotenv';
 import express from 'express';
 import crypto from 'crypto';
 import { exec } from 'child_process';
 import fs from 'fs';
 import path from 'path';
+
+// Load .env from ~/zylos/.env (absolute path, not cwd-dependent)
+dotenv.config({ path: path.join(process.env.HOME, 'zylos/.env') });
 
 import { getConfig, watchConfig, saveConfig, DATA_DIR, getCredentials } from './lib/config.js';
 import { downloadImage, downloadFile } from './lib/message.js';


### PR DESCRIPTION
## Summary
- Load .env from `~/zylos/.env` using explicit absolute path instead of `import 'dotenv/config'` which loads from cwd
- Fixes credential loading when running under PM2 where cwd is the skill directory

## Files changed
- `src/index.js`
- `src/cli.js`
- `scripts/send.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)