### PR TITLE
fix: use bot open_id for @mention detection in groups

### DIFF
--- a/src/lib/client.js
+++ b/src/lib/client.js
@@ -44,6 +44,30 @@ export function resetClient() {
 }
 
 /**
+ * Get bot info (open_id, name, etc.)
+ * Uses the /bot/v3/info endpoint
+ */
+export async function getBotInfo() {
+  const client = getClient();
+  try {
+    const res = await client.request({
+      method: 'GET',
+      url: '/open-apis/bot/v3/info',
+    });
+    if (res.code === 0 && res.bot) {
+      return {
+        success: true,
+        open_id: res.bot.open_id,
+        app_name: res.bot.app_name,
+      };
+    }
+    return { success: false, message: `API error: ${res.msg}` };
+  } catch (err) {
+    return { success: false, message: err.message };
+  }
+}
+
+/**
  * Test authentication by getting tenant access token
  */
 export async function testAuth() {


### PR DESCRIPTION
## Summary
- `isBotMentioned()` was comparing against `app_id` (`cli_xxx`) but Lark's mention data uses the bot's `open_id` (`ou_xxx`), so @mentions were never detected
- Added `getBotInfo()` in client.js that fetches bot identity via `/bot/v3/info` API
- Fetch bot `open_id` at startup and use it for mention matching

## Test plan
- [ ] @mention bot in a group chat → should be detected and forwarded to C4
- [ ] Private chat still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)