### PR TITLE
fix: bump SKILL.md version to beta.3

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lark
-version: 0.1.0-beta.2
+version: 0.1.0-beta.3
 description: Lark and Feishu communication channel
 type: communication
 


### PR DESCRIPTION
## Summary
- SKILL.md version was still 0.1.0-beta.2 while package.json was already beta.3
- The zylos CLI reads version from SKILL.md frontmatter, so `zylos info` and `components.json` showed the wrong version after upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)