### PR TITLE
fix(group): resolve @mentions and fix group permission logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0-beta.7] - 2026-02-08
+
+### Fixed
+- Resolve @_user_N placeholders to real names in group messages (context and current message)
+- Only strip bot's @mention from current message, preserve other @mentions with resolved names
+- Group permission: empty `allowed_groups` now means open access (all groups allowed), not closed access
+
+### Added
+- `resolveMentions()` function for Lark mention placeholder resolution
+
+---
+
 ## [0.1.0-beta.6] - 2026-02-08
 
 ### Changed

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lark
-version: 0.1.0-beta.6
+version: 0.1.0-beta.7
 description: Lark and Feishu communication channel
 type: communication
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos-lark",
-  "version": "0.1.0-beta.6",
+  "version": "0.1.0-beta.7",
   "description": "Lark and Feishu communication channel",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
## Summary
- Add `resolveMentions()` function that replaces Lark's `@_user_N` placeholders with real user names from the mentions array
- Only strip the **bot's** @mention from current message text — other @mentions are preserved with resolved names
- Log messages with resolved names so group context shows `[Howard]: @Hongyun 很好` instead of `[Howard]: @_user_1 很好`
- Fix group permission logic: empty `allowed_groups` now means **open access** (all groups allowed), not closed access that blocks all non-owner mentions

## Test plan
- [ ] Send @mention in group with empty `allowed_groups` — should respond (was blocked before)
- [ ] Verify context messages show real names instead of `@_user_N`
- [ ] Verify current message preserves @mentions to other users
- [ ] Verify bot's own @mention is stripped from current message

🤖 Generated with [Claude Code](https://claude.com/claude-code)