### PR TITLE
feat(group): lazy download for file/image messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0-beta.8] - 2026-02-08
+
+### Added
+- Lazy download for group file/image messages: log metadata (file_key, image_key, msg_id) instead of downloading immediately
+- File metadata appears naturally in group context when bot is @mentioned later
+- `download-file` CLI command for on-demand file download (`lark-cli download-file <msg_id> <file_key> <path>`)
+
+---
+
 ## [0.1.0-beta.7] - 2026-02-08
 
 ### Fixed

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lark
-version: 0.1.0-beta.7
+version: 0.1.0-beta.8
 description: Lark and Feishu communication channel
 type: communication
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos-lark",
-  "version": "0.1.0-beta.7",
+  "version": "0.1.0-beta.8",
   "description": "Lark and Feishu communication channel",
   "type": "module",
   "main": "src/index.js",

--- a/src/cli.js
+++ b/src/cli.js
@@ -8,7 +8,7 @@ import path from 'path';
 dotenv.config({ path: path.join(process.env.HOME, 'zylos/.env') });
 
 import { testAuth } from './lib/client.js';
-import { sendToGroup, sendToUser, listMessages, uploadImage, sendImage, uploadFile, sendFile, downloadImage } from './lib/message.js';
+import { sendToGroup, sendToUser, listMessages, uploadImage, sendImage, uploadFile, sendFile, downloadImage, downloadFile } from './lib/message.js';
 import { getDocument, getDocumentInfo, getWikiNode, getSpreadsheet, getSheetValues, writeSheetValues, copySheet, addSheet } from './lib/document.js';
 import { listEvents } from './lib/calendar.js';
 import { listChats, searchChats, listChatMembers } from './lib/chat.js';
@@ -31,6 +31,7 @@ Commands:
   send-image <chat_id> <path>    Send image to a chat
   send-file <chat_id> <path>     Send file to a chat
   download-image <msg_id> <key> <path>  Download image from message
+  download-file <msg_id> <key> <path>   Download file from message
   messages <chat_id> [options]   List messages in a chat
                                  --limit N    Max messages (default: 50)
                                  --today      Only today's messages
@@ -125,6 +126,14 @@ async function main() {
           process.exit(1);
         }
         result = await downloadImage(args[1], args[2], args[3]);
+        break;
+
+      case 'download-file':
+        if (args.length < 4) {
+          console.error('Usage: lark-cli download-file <message_id> <file_key> <save_path>');
+          process.exit(1);
+        }
+        result = await downloadFile(args[1], args[2], args[3]);
         break;
 
       case 'messages':

--- a/src/index.js
+++ b/src/index.js
@@ -364,8 +364,19 @@ app.post('/webhook', async (req, res) => {
     const { text, imageKey, fileKey, fileName } = extractMessageContent(message);
     console.log(`[lark] ${chatType} message from ${senderUserId}: ${(text || '').substring(0, 50) || '[media]'}...`);
 
-    // Log message (with mentions for name resolution)
-    logMessage(chatType, chatId, senderUserId, senderOpenId, text, messageId, event.header.create_time, mentions);
+    // Build log text with file/image metadata for lazy download context
+    let logText = text;
+    if (imageKey) {
+      const imageInfo = `[image, image_key: ${imageKey}, msg_id: ${messageId}]`;
+      logText = logText ? `${logText}\n${imageInfo}` : imageInfo;
+    }
+    if (fileKey) {
+      const fileInfo = `[file: ${fileName}, file_key: ${fileKey}, msg_id: ${messageId}]`;
+      logText = logText ? `${logText}\n${fileInfo}` : fileInfo;
+    }
+
+    // Log message (file metadata + mentions for name resolution in context)
+    logMessage(chatType, chatId, senderUserId, senderOpenId, logText, messageId, event.header.create_time, mentions);
 
     // Private chat handling
     if (chatType === 'p2p') {


### PR DESCRIPTION
## Summary
- Log file/image metadata (file_key, image_key, msg_id) in group message logs instead of downloading immediately
- File metadata appears naturally in group context when bot is @mentioned later
- Add `download-file` CLI command for on-demand file download

## Background
In Lark, you can't @mention the bot when sending files. So file messages never trigger the bot. With lazy download, file metadata is recorded in the group log and surfaces naturally in context the next time someone @mentions the bot.

## Context format
```
[file: report.pdf, file_key: file_v3_xxx, msg_id: om_xxx]
[image, image_key: img_v3_xxx, msg_id: om_xxx]
```

## On-demand download
```bash
lark-cli download-image <msg_id> <image_key> <save_path>
lark-cli download-file <msg_id> <file_key> <save_path>
```

## Test plan
- [ ] Send a file in a group (without @mention) — metadata should be logged
- [ ] @mention the bot after — context should include the file metadata
- [ ] `lark-cli download-file` should work with the logged msg_id + file_key

🤖 Generated with [Claude Code](https://claude.com/claude-code)