### PR TITLE
refactor(hooks): update for lifecycle refactor

### DIFF
--- a/hooks/post-install.js
+++ b/hooks/post-install.js
@@ -2,11 +2,9 @@
 /**
  * Post-install hook for zylos-lark
  *
- * Called by zylos CLI after standard installation steps:
- * - git clone
- * - npm install
- * - create data_dir
- * - register PM2 service (uses ecosystem.config.cjs automatically)
+ * Called by Claude after CLI installation (zylos add --json).
+ * CLI handles: download, npm install, manifest, registration.
+ * Claude handles: config collection, this hook, service start.
  *
  * This hook handles lark-specific setup:
  * - Create subdirectories (logs, media)
@@ -67,8 +65,7 @@ if (!hasAppId || !hasAppSecret) {
   if (!hasAppSecret) console.log('    LARK_APP_SECRET=your_app_secret');
 }
 
-// Note: PM2 service is configured by zylos CLI's registerService()
-// which automatically uses ecosystem.config.cjs when available.
+// Note: PM2 service is started by Claude after this hook completes.
 
 console.log('\n[post-install] Complete!');
 

--- a/hooks/post-upgrade.js
+++ b/hooks/post-upgrade.js
@@ -2,15 +2,14 @@
 /**
  * Post-upgrade hook for zylos-lark
  *
- * Called by zylos CLI after standard upgrade steps:
- * - git pull
- * - npm install
+ * Called by Claude after CLI upgrade completes (zylos upgrade --json).
+ * CLI handles: stop service, backup, file sync, npm install, manifest.
  *
  * This hook handles component-specific migrations:
  * - Config schema migrations
  * - Data format updates
  *
- * Note: Service restart is handled by zylos CLI after this hook.
+ * Note: Service restart is handled by Claude after this hook.
  */
 
 import fs from 'fs';

--- a/hooks/pre-upgrade.js
+++ b/hooks/pre-upgrade.js
@@ -2,9 +2,8 @@
 /**
  * Pre-upgrade hook for zylos-lark
  *
- * Called by zylos CLI BEFORE upgrade steps:
- * - git pull
- * - npm install
+ * Called by Claude BEFORE CLI upgrade steps.
+ * If this hook fails (exit code 1), the upgrade is aborted.
  *
  * This hook handles:
  * - Backup critical data before upgrade


### PR DESCRIPTION
## Summary

- Updated hook comments to reflect new ownership: hooks are called by Claude, not CLI
- pre-upgrade.js: "Called by zylos CLI" → "Called by Claude"
- post-upgrade.js: "Called by zylos CLI" → "Called by Claude", service restart by Claude

Part of the lifecycle refactor (see zylos-core PR).

## Test plan

- [ ] `node hooks/post-install.js` still runs correctly
- [ ] `node hooks/pre-upgrade.js` backs up config.json
- [ ] `node hooks/post-upgrade.js` runs config migrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)