### PR TITLE
chore: release v0.1.0-beta.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0-beta.10] - 2026-02-09
+
+### Changed
+- Version bump for upgrade flow testing
+
+---
+
 ## [0.1.0-beta.9] - 2026-02-09
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos-lark",
-  "version": "0.1.0-beta.9",
+  "version": "0.1.0-beta.10",
   "description": "Lark and Feishu communication channel",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
## Summary
- Version bump to v0.1.0-beta.10 for upgrade flow testing

## After merge
- Tag `v0.1.0-beta.10` and `npm publish`

🤖 Generated with [Claude Code](https://claude.com/claude-code)