### PR TITLE
fix(caddy): add strip_prefix to webhook route

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -32,12 +32,13 @@ config:
       description: "App Secret (same page as App ID)"
       sensitive: true
     - name: LARK_WEBHOOK_URL
-      description: "Public webhook URL for Feishu/Lark callbacks (e.g. https://yourdomain.com/webhook)"
+      description: "Public webhook URL for Feishu/Lark callbacks (e.g. https://yourdomain.com/lark/webhook)"
 
 http_routes:
   - path: /lark/webhook
     type: reverse_proxy
     target: localhost:3457
+    strip_prefix: /lark
 
 dependencies:
   - comm-bridge
@@ -142,7 +143,7 @@ Add to `~/zylos/.env`:
 ```bash
 LARK_APP_ID=your_app_id
 LARK_APP_SECRET=your_app_secret
-LARK_WEBHOOK_URL=https://yourdomain.com/webhook
+LARK_WEBHOOK_URL=https://yourdomain.com/lark/webhook
 ```
 
 Get App ID and App Secret from your app's Credentials page:

--- a/hooks/post-install.js
+++ b/hooks/post-install.js
@@ -64,7 +64,7 @@ if (!hasAppId || !hasAppSecret || !hasWebhookUrl) {
   console.log('    Please add:');
   if (!hasAppId) console.log('    LARK_APP_ID=your_app_id');
   if (!hasAppSecret) console.log('    LARK_APP_SECRET=your_app_secret');
-  if (!hasWebhookUrl) console.log('    LARK_WEBHOOK_URL=https://yourdomain.com/webhook');
+  if (!hasWebhookUrl) console.log('    LARK_WEBHOOK_URL=https://yourdomain.com/lark/webhook');
 }
 
 // Read webhook URL for display in setup checklist
@@ -87,7 +87,7 @@ console.log('');
 console.log('1. Add credentials to ~/zylos/.env:');
 console.log('   LARK_APP_ID=your_app_id');
 console.log('   LARK_APP_SECRET=your_app_secret');
-console.log('   LARK_WEBHOOK_URL=https://yourdomain.com/webhook');
+console.log('   LARK_WEBHOOK_URL=https://yourdomain.com/lark/webhook');
 console.log('');
 console.log('2. In Feishu/Lark developer console:');
 console.log('   - Feishu: open.feishu.cn/app');


### PR DESCRIPTION
## Summary

- Add `strip_prefix: /lark` to http_routes in SKILL.md so Caddy strips the `/lark` prefix before forwarding to Express
- Without this, Caddy forwards `/lark/webhook` to Express which only listens on `/webhook`, causing 404
- Update webhook URL examples from `/webhook` to `/lark/webhook` in SKILL.md and post-install hook

## Root Cause

```
Request: POST /lark/webhook
  → Caddy handle /lark/webhook → reverse_proxy localhost:3457
  → Express receives /lark/webhook → no route match → 404
```

## Fix

```yaml
http_routes:
  - path: /lark/webhook
    type: reverse_proxy
    target: localhost:3457
    strip_prefix: /lark    # ← added
```

Now Caddy strips `/lark`, forwarding `/webhook` to Express which matches `app.post('/webhook')`.

## Test plan

- [ ] Deploy with updated SKILL.md, verify Caddy generates correct config with `uri strip_prefix /lark`
- [ ] Confirm Lark webhook verification passes
- [ ] Confirm Lark event messages reach Express successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)