### PR TITLE
fix(security): default group whitelist to deny-all except owner

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -112,6 +112,10 @@ node ~/zylos/.claude/skills/lark/src/admin.js list-smart-groups
 node ~/zylos/.claude/skills/lark/src/admin.js add-smart-group <chat_id> <name>
 node ~/zylos/.claude/skills/lark/src/admin.js remove-smart-group <chat_id>
 
+# Group Whitelist (enabled by default)
+node ~/zylos/.claude/skills/lark/src/admin.js enable-group-whitelist
+node ~/zylos/.claude/skills/lark/src/admin.js disable-group-whitelist
+
 # Whitelist
 node ~/zylos/.claude/skills/lark/src/admin.js list-whitelist
 node ~/zylos/.claude/skills/lark/src/admin.js add-whitelist <user_id_or_open_id>

--- a/src/admin.js
+++ b/src/admin.js
@@ -231,6 +231,30 @@ const commands = {
     console.log('Run: pm2 restart zylos-lark');
   },
 
+  'enable-group-whitelist': () => {
+    const config = loadConfig();
+    if (!config.group_whitelist) {
+      config.group_whitelist = { enabled: true };
+    } else {
+      config.group_whitelist.enabled = true;
+    }
+    saveConfig(config);
+    console.log('Group whitelist enabled. Only allowed_groups + owner can trigger bot in groups.');
+    console.log('Run: pm2 restart zylos-lark');
+  },
+
+  'disable-group-whitelist': () => {
+    const config = loadConfig();
+    if (!config.group_whitelist) {
+      config.group_whitelist = { enabled: false };
+    } else {
+      config.group_whitelist.enabled = false;
+    }
+    saveConfig(config);
+    console.log('Group whitelist disabled. All groups can trigger bot (open mode).');
+    console.log('Run: pm2 restart zylos-lark');
+  },
+
   'show-owner': () => {
     const config = loadConfig();
     const owner = config.owner || {};
@@ -260,6 +284,10 @@ Commands:
   add-smart-group <chat_id> <name>    Add a smart group
   remove-smart-group <chat_id>        Remove a smart group
 
+  Group Whitelist:
+  enable-group-whitelist              Enable group whitelist (default, secure)
+  disable-group-whitelist             Disable group whitelist (open mode)
+
   Whitelist (access control):
   list-whitelist                      List whitelist entries
   add-whitelist <user_id_or_open_id>  Add to whitelist
@@ -268,6 +296,8 @@ Commands:
   disable-whitelist                   Disable whitelist (allow all)
 
   show-owner                          Show current owner
+
+Note: Owner can always @mention bot in any group regardless of whitelist.
 
 After changes, restart bot: pm2 restart zylos-lark
 `);

--- a/src/index.js
+++ b/src/index.js
@@ -537,9 +537,13 @@ app.post('/webhook', async (req, res) => {
       const mentioned = isBotMentioned(mentions, botOpenId);
       const isSmartGroup = (config.smart_groups || []).some(g => g.chat_id === chatId);
       const allowedGroups = config.allowed_groups || [];
-      // If allowed_groups is empty, all groups are allowed (open mode)
-      // If allowed_groups has entries, only listed groups are allowed (restricted mode)
-      const isAllowedGroup = allowedGroups.length === 0 || allowedGroups.some(g => g.chat_id === chatId);
+      // When group_whitelist.enabled is true (default): only listed groups are allowed
+      // When group_whitelist.enabled is false: all groups are allowed (open mode)
+      // Owner is always allowed — checked separately below
+      const whitelistEnabled = config.group_whitelist?.enabled !== false;
+      const isAllowedGroup = whitelistEnabled
+        ? allowedGroups.some(g => g.chat_id === chatId)
+        : true;
 
       // Smart groups: receive all messages
       // Allowed groups (or open mode): respond to @mentions

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -34,6 +34,8 @@ export const DEFAULT_CONFIG = {
     private_users: [],
     group_users: []
   },
+  // Group whitelist (enabled by default for security)
+  group_whitelist: { enabled: true },
   // Allowed groups (respond to @mentions)
   // Format: [{chat_id: "oc_xxx", name: "Group Name", added_at: "ISO timestamp"}]
   allowed_groups: [],


### PR DESCRIPTION
## Summary

- Added `group_whitelist.enabled` config flag (default: `true`)
- When enabled + `allowed_groups` empty: only owner can trigger bot in groups (deny-by-default)
- When disabled: all groups can trigger bot (open mode, for testing)
- Owner always exempt regardless of whitelist setting
- Added admin CLI: `enable-group-whitelist`, `disable-group-whitelist`

## Problem

Empty `allowed_groups` previously meant all groups were allowed (open mode). Any user in any group could @mention and trigger the bot, which is a security risk.

## Test plan

- [ ] Fresh install: bot should not respond to non-owner @mentions in groups
- [ ] Owner @mention in any group: should always work
- [ ] After `add-allowed-group`: non-owner @mention in that group should work
- [ ] `disable-group-whitelist`: all groups should work (old behavior)
- [ ] Smart groups: should be unaffected by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)