### PR TITLE
fix: switch API domain from Feishu to Lark international

### DIFF
--- a/src/lib/client.js
+++ b/src/lib/client.js
@@ -30,7 +30,7 @@ export function getClient() {
     appId: creds.app_id,
     appSecret: creds.app_secret,
     appType: lark.AppType.SelfBuild,
-    domain: lark.Domain.Feishu,  // Chinese version (feishu.cn)
+    domain: lark.Domain.Lark,  // International version (larksuite.com)
   });
 
   return clientInstance;

--- a/src/lib/message.js
+++ b/src/lib/message.js
@@ -18,7 +18,7 @@ async function getAccessToken() {
 
   const res = await axios({
     method: 'POST',
-    url: 'https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal',
+    url: 'https://open.larksuite.com/open-apis/auth/v3/tenant_access_token/internal',
     headers: { 'Content-Type': 'application/json' },
     data: { app_id: creds.app_id, app_secret: creds.app_secret },
     proxy
@@ -141,7 +141,7 @@ export async function downloadImage(messageId, imageKey, savePath) {
 
     const res = await axios({
       method: 'GET',
-      url: `https://open.feishu.cn/open-apis/im/v1/messages/${messageId}/resources/${imageKey}?type=image`,
+      url: `https://open.larksuite.com/open-apis/im/v1/messages/${messageId}/resources/${imageKey}?type=image`,
       headers: { 'Authorization': 'Bearer ' + token },
       responseType: 'arraybuffer',
       proxy
@@ -172,7 +172,7 @@ export async function uploadImage(imagePath, imageType = 'message') {
 
     const res = await axios({
       method: 'POST',
-      url: 'https://open.feishu.cn/open-apis/im/v1/images',
+      url: 'https://open.larksuite.com/open-apis/im/v1/images',
       headers: {
         'Authorization': 'Bearer ' + token,
         ...form.getHeaders()
@@ -227,7 +227,7 @@ export async function downloadFile(messageId, fileKey, savePath) {
 
     const res = await axios({
       method: 'GET',
-      url: `https://open.feishu.cn/open-apis/im/v1/messages/${messageId}/resources/${fileKey}?type=file`,
+      url: `https://open.larksuite.com/open-apis/im/v1/messages/${messageId}/resources/${fileKey}?type=file`,
       headers: { 'Authorization': 'Bearer ' + token },
       responseType: 'arraybuffer',
       proxy


### PR DESCRIPTION
## Summary
- Switch SDK domain from `Domain.Feishu` to `Domain.Lark`
- Replace hardcoded `open.feishu.cn` URLs with `open.larksuite.com` in message.js

## Test plan
- [x] Tested in production: private chat send/receive works
- [x] Tested in production: group chat send/receive works
- [x] Feishu app credentials work with Lark international domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)