### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3] - 2026-02-14
+
+### Changed
+- Switch API domain from Feishu (open.feishu.cn) to Lark international (open.larksuite.com) (#29)
+
 ## [0.1.2] - 2026-02-13
 
 ### Fixed

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lark
-version: 0.1.2
+version: 0.1.3
 description: Lark and Feishu communication channel
 type: communication
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zylos-lark",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zylos-lark",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.0.0",
@@ -14,6 +14,9 @@
         "dotenv": "^16.4.5",
         "express": "^4.18.2",
         "form-data": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@larksuiteoapi/node-sdk": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos-lark",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Lark and Feishu communication channel",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
## Summary
- Bump version to 0.1.3
- Update CHANGELOG and SKILL.md version

### Changes in v0.1.3
- Switch API domain from Feishu (open.feishu.cn) to Lark international (open.larksuite.com) (#29)

🤖 Generated with [Claude Code](https://claude.com/claude-code)