### PR TITLE
feat: make verification_token required for webhook security

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -32,7 +32,7 @@ config:
       description: "App Secret (same page as App ID)"
       sensitive: true
 
-next-steps: "After starting the service: 1) Read domain from ~/zylos/.zylos/config.json and tell user to configure webhook URL in the developer console — Feishu: open.feishu.cn/app, Lark: open.larksuite.com/app (Event Subscriptions → Request URL → https://{domain}/lark/webhook). 2) Ask if user wants to configure verification token (optional, from Event Subscriptions page) — if yes, write to config.bot.verification_token in ~/zylos/components/lark/config.json, then pm2 restart zylos-lark."
+next-steps: "BEFORE starting the service: 1) Ask user for their Verification Token (REQUIRED — from developer console Event Subscriptions page). Write to config.bot.verification_token in ~/zylos/components/lark/config.json. The service will refuse to start without it. 2) Optionally ask for Encrypt Key — if provided, write to config.bot.encrypt_key. 3) Read domain from ~/zylos/.zylos/config.json and tell user to configure webhook URL in the developer console — Feishu: open.feishu.cn/app, Lark: open.larksuite.com/app (Event Subscriptions → Request URL → https://{domain}/lark/webhook). 4) Start the service (pm2 restart zylos-lark)."
 
 http_routes:
   - path: /lark/webhook
@@ -165,9 +165,9 @@ In the Feishu/Lark developer console:
 
 ### 3. Event Security (Optional)
 
-Feishu/Lark provides two security mechanisms for webhook events. You can use either or both.
+Feishu/Lark provides two security mechanisms for webhook events.
 
-**Verification Token** — validates that requests come from Feishu/Lark:
+**Verification Token** (REQUIRED) — validates that requests come from Feishu/Lark. The service will refuse to start without it.
 
 In the console: Event subscriptions → Verification Token. Add to config:
 

--- a/hooks/post-install.js
+++ b/hooks/post-install.js
@@ -10,7 +10,7 @@
  * - Create subdirectories (logs, media)
  * - Create default config.json
  * - Check for environment variables (informational)
- * - Prompt for verification token (terminal mode only, optional)
+ * - Prompt for verification token (terminal mode only, required)
  */
 
 import fs from 'fs';
@@ -83,25 +83,26 @@ if (!hasAppId || !hasAppSecret) {
 
 // 4. Prompt for verification token (terminal mode only)
 if (isInteractive) {
-  const answer = await ask('\nConfigure verification token? (optional, enhances security) [y/N]: ');
-  if (answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes') {
-    const token = await ask('  Verification Token (from Event Subscriptions page): ');
-    if (token) {
-      const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
-      config.bot = config.bot || {};
-      config.bot.verification_token = token;
-      fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
-      console.log('  ✓ Verification token saved to config.json');
-    }
+  console.log('\nVerification Token (REQUIRED for webhook security):');
+  const token = await ask('  Verification Token (from Event Subscriptions page): ');
+  if (token) {
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    config.bot = config.bot || {};
+    config.bot.verification_token = token;
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+    console.log('  ✓ Verification token saved to config.json');
+  } else {
+    console.log('  WARNING: Verification token is required for the service to start.');
+    console.log('  You must set bot.verification_token in config.json before starting.');
+  }
 
-    const encryptKey = await ask('  Encrypt Key (optional, for payload encryption) [press Enter to skip]: ');
-    if (encryptKey) {
-      const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
-      config.bot = config.bot || {};
-      config.bot.encrypt_key = encryptKey;
-      fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
-      console.log('  ✓ Encrypt key saved to config.json');
-    }
+  const encryptKey = await ask('  Encrypt Key (optional, for payload encryption) [press Enter to skip]: ');
+  if (encryptKey) {
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    config.bot = config.bot || {};
+    config.bot.encrypt_key = encryptKey;
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+    console.log('  ✓ Encrypt key saved to config.json');
   }
 }
 

--- a/hooks/post-upgrade.js
+++ b/hooks/post-upgrade.js
@@ -44,15 +44,9 @@ if (fs.existsSync(configPath)) {
 
     // Migration 3: Ensure bot settings
     if (!config.bot) {
-      config.bot = { encrypt_key: '' };
+      config.bot = { encrypt_key: '', verification_token: '' };
       migrated = true;
       migrations.push('Added bot settings');
-    }
-    // Clean up removed field
-    if (config.bot.verification_token !== undefined) {
-      delete config.bot.verification_token;
-      migrated = true;
-      migrations.push('Removed unused bot.verification_token');
     }
 
     // Migration 4: Ensure owner structure


### PR DESCRIPTION
## Summary

- `verification_token` is now **required** — the service refuses to start without it
- Previously optional, meaning the webhook endpoint accepted any POST request without verifying origin
- This is a security hardening for production deployments

## Changes

| File | Change |
|------|--------|
| `src/index.js` | Startup check: exit with error if `bot.verification_token` missing. Webhook handler: return 500 if somehow missing at runtime |
| `hooks/post-install.js` | Prompt for token directly (no longer wrapped in "optional" yes/no question) |
| `hooks/post-upgrade.js` | Removed migration that was deleting `verification_token` from config |
| `SKILL.md` | Marked verification_token as REQUIRED in docs and next-steps |

## Test Plan

- [ ] Service refuses to start when `bot.verification_token` is empty/missing in config.json
- [ ] Service starts normally when `bot.verification_token` is set
- [ ] Webhook rejects requests with mismatched token (403)
- [ ] Post-install hook prompts for verification token without optional gate
- [ ] Upgrade from older version preserves existing verification_token

🤖 Generated with [Claude Code](https://claude.com/claude-code)