### PR TITLE
feat: require verification_token + webhook dedup and immediate response

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -32,7 +32,7 @@ config:
       description: "App Secret (same page as App ID)"
       sensitive: true
 
-next-steps: "After starting the service: 1) Read domain from ~/zylos/.zylos/config.json and tell user to configure webhook URL in the developer console — Feishu: open.feishu.cn/app, Lark: open.larksuite.com/app (Event Subscriptions → Request URL → https://{domain}/lark/webhook). 2) Ask if user wants to configure verification token (optional, from Event Subscriptions page) — if yes, write to config.bot.verification_token in ~/zylos/components/lark/config.json, then pm2 restart zylos-lark."
+next-steps: "BEFORE starting the service: 1) Ask user for their Verification Token (REQUIRED — from developer console Event Subscriptions page). Write to config.bot.verification_token in ~/zylos/components/lark/config.json. The service will refuse to start without it. 2) Optionally ask for Encrypt Key — if provided, write to config.bot.encrypt_key. 3) Read domain from ~/zylos/.zylos/config.json and tell user to configure webhook URL in the developer console — Feishu: open.feishu.cn/app, Lark: open.larksuite.com/app (Event Subscriptions → Request URL → https://{domain}/lark/webhook). 4) Start the service (pm2 restart zylos-lark)."
 
 http_routes:
   - path: /lark/webhook
@@ -163,11 +163,11 @@ In the Feishu/Lark developer console:
 2. **Subscribe to events**: Event subscriptions → Add `im.message.receive_v1`
 3. **Set Request URL**: Event subscriptions → Request URL → `https://<your-domain>/lark/webhook` (the path is defined by `http_routes` in SKILL.md)
 
-### 3. Event Security (Optional)
+### 3. Event Security
 
-Feishu/Lark provides two security mechanisms for webhook events. You can use either or both.
+Feishu/Lark provides two security mechanisms for webhook events.
 
-**Verification Token** — validates that requests come from Feishu/Lark:
+**Verification Token** (REQUIRED) — validates that requests come from Feishu/Lark. The service will refuse to start without it.
 
 In the console: Event subscriptions → Verification Token. Add to config:
 

--- a/hooks/post-install.js
+++ b/hooks/post-install.js
@@ -10,7 +10,7 @@
  * - Create subdirectories (logs, media)
  * - Create default config.json
  * - Check for environment variables (informational)
- * - Prompt for verification token (terminal mode only, optional)
+ * - Prompt for verification token (terminal mode only, required)
  */
 
 import fs from 'fs';
@@ -83,25 +83,26 @@ if (!hasAppId || !hasAppSecret) {
 
 // 4. Prompt for verification token (terminal mode only)
 if (isInteractive) {
-  const answer = await ask('\nConfigure verification token? (optional, enhances security) [y/N]: ');
-  if (answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes') {
-    const token = await ask('  Verification Token (from Event Subscriptions page): ');
-    if (token) {
-      const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
-      config.bot = config.bot || {};
-      config.bot.verification_token = token;
-      fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
-      console.log('  ✓ Verification token saved to config.json');
-    }
+  console.log('\nVerification Token (REQUIRED for webhook security):');
+  const token = await ask('  Verification Token (from Event Subscriptions page): ');
+  if (token) {
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    config.bot = config.bot || {};
+    config.bot.verification_token = token;
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+    console.log('  ✓ Verification token saved to config.json');
+  } else {
+    console.log('  WARNING: Verification token is required for the service to start.');
+    console.log('  You must set bot.verification_token in config.json before starting.');
+  }
 
-    const encryptKey = await ask('  Encrypt Key (optional, for payload encryption) [press Enter to skip]: ');
-    if (encryptKey) {
-      const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
-      config.bot = config.bot || {};
-      config.bot.encrypt_key = encryptKey;
-      fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
-      console.log('  ✓ Encrypt key saved to config.json');
-    }
+  const encryptKey = await ask('  Encrypt Key (optional, for payload encryption) [press Enter to skip]: ');
+  if (encryptKey) {
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    config.bot = config.bot || {};
+    config.bot.encrypt_key = encryptKey;
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+    console.log('  ✓ Encrypt key saved to config.json');
   }
 }
 

--- a/hooks/post-upgrade.js
+++ b/hooks/post-upgrade.js
@@ -48,12 +48,6 @@ if (fs.existsSync(configPath)) {
       migrated = true;
       migrations.push('Added bot settings');
     }
-    // Clean up removed field
-    if (config.bot.verification_token !== undefined) {
-      delete config.bot.verification_token;
-      migrated = true;
-      migrations.push('Removed unused bot.verification_token');
-    }
 
     // Migration 4: Ensure owner structure
     if (!config.owner) {

--- a/src/index.js
+++ b/src/index.js
@@ -417,12 +417,33 @@ function isWhitelisted(userId, openId) {
   return allowedUsers.includes(userId) || (openId && allowedUsers.includes(openId));
 }
 
+// Dedup: track recently processed message_ids (TTL 5 minutes)
+const DEDUP_TTL = 5 * 60 * 1000;
+const processedMessages = new Map();
+
+function isDuplicate(messageId) {
+  if (!messageId) return false;
+  if (processedMessages.has(messageId)) {
+    console.log(`[lark] Duplicate message_id ${messageId}, skipping`);
+    return true;
+  }
+  processedMessages.set(messageId, Date.now());
+  // Cleanup old entries
+  if (processedMessages.size > 100) {
+    const now = Date.now();
+    for (const [id, ts] of processedMessages) {
+      if (now - ts > DEDUP_TTL) processedMessages.delete(id);
+    }
+  }
+  return false;
+}
+
 // Express app
 const app = express();
 app.use(express.json());
 
 // Webhook endpoint
-app.post('/webhook', async (req, res) => {
+app.post('/webhook', (req, res) => {
   console.log('[lark] Received webhook request');
 
   let event = req.body;
@@ -437,14 +458,16 @@ app.post('/webhook', async (req, res) => {
     }
   }
 
-  // Verify token if configured
+  // Verify token (required)
   const verificationToken = config.bot?.verification_token;
-  if (verificationToken) {
-    const eventToken = event.token || event.header?.token;
-    if (eventToken !== verificationToken) {
-      console.warn(`[lark] Verification token mismatch, rejecting request`);
-      return res.status(403).json({ error: 'Token verification failed' });
-    }
+  if (!verificationToken) {
+    console.error('[lark] verification_token not configured — rejecting request. Set bot.verification_token in config.json.');
+    return res.status(500).json({ error: 'Server misconfigured: verification_token missing' });
+  }
+  const eventToken = event.token || event.header?.token;
+  if (eventToken !== verificationToken) {
+    console.warn(`[lark] Verification token mismatch, rejecting request`);
+    return res.status(403).json({ error: 'Token verification failed' });
   }
 
   // URL Verification Challenge
@@ -453,162 +476,165 @@ app.post('/webhook', async (req, res) => {
     return res.json({ challenge: event.challenge });
   }
 
-  // Handle message event
+  // Respond immediately to prevent Lark retry (timeout ~15s)
+  res.json({ code: 0 });
+
+  // Handle message event asynchronously
   if (event.header?.event_type === 'im.message.receive_v1') {
-    const message = event.event.message;
-    const sender = event.event.sender;
-    const mentions = message.mentions;
+    const messageId = event.event?.message?.message_id;
+    if (isDuplicate(messageId)) return;
 
-    const senderUserId = sender.sender_id?.user_id;
-    const senderOpenId = sender.sender_id?.open_id;
-    const chatId = message.chat_id;
-    const messageId = message.message_id;
-    const chatType = message.chat_type;
+    handleMessageEvent(event).catch(err => {
+      console.error(`[lark] Error handling message: ${err.message}`);
+    });
+  }
+});
 
-    const { text, imageKey, fileKey, fileName } = extractMessageContent(message);
-    console.log(`[lark] ${chatType} message from ${senderUserId}: ${(text || '').substring(0, 50) || '[media]'}...`);
+/**
+ * Process a message event asynchronously (after HTTP response sent).
+ */
+async function handleMessageEvent(event) {
+  const message = event.event.message;
+  const sender = event.event.sender;
+  const mentions = message.mentions;
 
-    // Build log text with file/image metadata for lazy download context
-    let logText = text;
-    if (imageKey) {
-      const imageInfo = `[image, image_key: ${imageKey}, msg_id: ${messageId}]`;
-      logText = logText ? `${logText}\n${imageInfo}` : imageInfo;
-    }
-    if (fileKey) {
-      const fileInfo = `[file: ${fileName}, file_key: ${fileKey}, msg_id: ${messageId}]`;
-      logText = logText ? `${logText}\n${fileInfo}` : fileInfo;
-    }
+  const senderUserId = sender.sender_id?.user_id;
+  const senderOpenId = sender.sender_id?.open_id;
+  const chatId = message.chat_id;
+  const messageId = message.message_id;
+  const chatType = message.chat_type;
 
-    // Log message (file metadata + mentions for name resolution in context)
-    logMessage(chatType, chatId, senderUserId, senderOpenId, logText, messageId, event.header.create_time, mentions);
+  const { text, imageKey, fileKey, fileName } = extractMessageContent(message);
+  console.log(`[lark] ${chatType} message from ${senderUserId}: ${(text || '').substring(0, 50) || '[media]'}...`);
 
-    // Private chat handling
-    if (chatType === 'p2p') {
-      // Auto-bind first private chat user as owner
-      if (!config.owner?.bound) {
-        await bindOwner(senderUserId, senderOpenId);
-      }
-
-      if (!isWhitelisted(senderUserId, senderOpenId)) {
-        console.log(`[lark] Private message from non-whitelisted user ${senderUserId}, ignoring`);
-        return res.json({ code: 0 });
-      }
-
-      const senderName = await resolveUserName(senderUserId);
-      const rejectReply = (errMsg) => {
-        sendMessage(chatId, errMsg).catch(e => console.error('[lark] reject reply failed:', e.message));
-      };
-
-      if (imageKey) {
-        const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-        const localPath = path.join(MEDIA_DIR, `lark-${timestamp}.png`);
-        const result = await downloadImage(messageId, imageKey, localPath);
-        if (result.success) {
-          const message = formatMessage('p2p', senderName, `[image]${text ? ' ' + text : ''}`, [], localPath);
-          sendToC4('lark', chatId, message, rejectReply);
-        } else {
-          const message = formatMessage('p2p', senderName, '[image download failed]');
-          sendToC4('lark', chatId, message, rejectReply);
-        }
-        return res.json({ code: 0 });
-      }
-
-      if (fileKey) {
-        const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-        const localPath = path.join(MEDIA_DIR, `lark-${timestamp}-${fileName}`);
-        const result = await downloadFile(messageId, fileKey, localPath);
-        if (result.success) {
-          const message = formatMessage('p2p', senderName, `[file: ${fileName}]`, [], localPath);
-          sendToC4('lark', chatId, message, rejectReply);
-        } else {
-          const message = formatMessage('p2p', senderName, `[file download failed: ${fileName}]`);
-          sendToC4('lark', chatId, message, rejectReply);
-        }
-        return res.json({ code: 0 });
-      }
-
-      const message = formatMessage('p2p', senderName, text);
-      sendToC4('lark', chatId, message, rejectReply);
-      return res.json({ code: 0 });
-    }
-
-    // Group chat handling
-    if (chatType === 'group') {
-      const mentioned = isBotMentioned(mentions, botOpenId);
-      const isSmartGroup = (config.smart_groups || []).some(g => g.chat_id === chatId);
-      const allowedGroups = config.allowed_groups || [];
-      // When group_whitelist.enabled is true (default): only listed groups are allowed
-      // When group_whitelist.enabled is false: all groups are allowed (open mode)
-      // Owner is always allowed — checked separately below
-      const whitelistEnabled = config.group_whitelist?.enabled !== false;
-      const isAllowedGroup = whitelistEnabled
-        ? allowedGroups.some(g => g.chat_id === chatId)
-        : true;
-
-      // Smart groups: receive all messages
-      // Allowed groups (or open mode): respond to @mentions
-      // Non-allowed groups: log only
-      if (!isSmartGroup && !mentioned) {
-        console.log(`[lark] Group message without @mention, logged only`);
-        return res.json({ code: 0 });
-      }
-
-      // For non-smart groups, need @mention and permission check
-      if (!isSmartGroup) {
-        const senderIsOwner = isOwner(senderUserId, senderOpenId);
-
-        // Owner can @mention bot in any group
-        if (!isAllowedGroup && !senderIsOwner) {
-          console.log(`[lark] @mention in non-allowed group ${chatId}, ignoring`);
-          return res.json({ code: 0 });
-        }
-        if (!senderIsOwner && !isWhitelisted(senderUserId, senderOpenId)) {
-          console.log(`[lark] @mention from non-whitelisted user ${senderUserId} in group, ignoring`);
-          return res.json({ code: 0 });
-        }
-      }
-
-      console.log(`[lark] ${isSmartGroup ? 'Smart group' : 'Bot @mentioned in'} group ${chatId}`);
-      const contextMessages = getGroupContext(chatId, messageId);
-      updateCursor(chatId, messageId);
-
-      const senderName = await resolveUserName(senderUserId);
-      // Resolve mentions: replace @_user_N with real names, strip bot's @mention only
-      const cleanText = resolveMentions(text, mentions, { stripBot: true, botOpenId });
-      const groupRejectReply = (errMsg) => {
-        sendMessage(chatId, errMsg).catch(e => console.error('[lark] reject reply failed:', e.message));
-      };
-
-      if (imageKey) {
-        const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-        const localPath = path.join(MEDIA_DIR, `lark-group-${timestamp}.png`);
-        const result = await downloadImage(messageId, imageKey, localPath);
-        if (result.success) {
-          const message = formatMessage('group', senderName, `[image]${cleanText ? ' ' + cleanText : ''}`, contextMessages, localPath);
-          sendToC4('lark', chatId, message, groupRejectReply);
-        }
-        return res.json({ code: 0 });
-      }
-
-      if (fileKey) {
-        const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-        const localPath = path.join(MEDIA_DIR, `lark-group-${timestamp}-${fileName}`);
-        const result = await downloadFile(messageId, fileKey, localPath);
-        if (result.success) {
-          const message = formatMessage('group', senderName, `[file: ${fileName}]${cleanText ? ' ' + cleanText : ''}`, contextMessages, localPath);
-          sendToC4('lark', chatId, message, groupRejectReply);
-        }
-        return res.json({ code: 0 });
-      }
-
-      const message = formatMessage('group', senderName, cleanText || text, contextMessages);
-      sendToC4('lark', chatId, message, groupRejectReply);
-      return res.json({ code: 0 });
-    }
+  // Build log text with file/image metadata for lazy download context
+  let logText = text;
+  if (imageKey) {
+    const imageInfo = `[image, image_key: ${imageKey}, msg_id: ${messageId}]`;
+    logText = logText ? `${logText}\n${imageInfo}` : imageInfo;
+  }
+  if (fileKey) {
+    const fileInfo = `[file: ${fileName}, file_key: ${fileKey}, msg_id: ${messageId}]`;
+    logText = logText ? `${logText}\n${fileInfo}` : fileInfo;
   }
 
-  res.json({ code: 0 });
-});
+  // Log message (file metadata + mentions for name resolution in context)
+  logMessage(chatType, chatId, senderUserId, senderOpenId, logText, messageId, event.header.create_time, mentions);
+
+  // Private chat handling
+  if (chatType === 'p2p') {
+    // Auto-bind first private chat user as owner
+    if (!config.owner?.bound) {
+      await bindOwner(senderUserId, senderOpenId);
+    }
+
+    if (!isWhitelisted(senderUserId, senderOpenId)) {
+      console.log(`[lark] Private message from non-whitelisted user ${senderUserId}, ignoring`);
+      return;
+    }
+
+    const senderName = await resolveUserName(senderUserId);
+    const rejectReply = (errMsg) => {
+      sendMessage(chatId, errMsg).catch(e => console.error('[lark] reject reply failed:', e.message));
+    };
+
+    if (imageKey) {
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+      const localPath = path.join(MEDIA_DIR, `lark-${timestamp}.png`);
+      const result = await downloadImage(messageId, imageKey, localPath);
+      if (result.success) {
+        const msg = formatMessage('p2p', senderName, `[image]${text ? ' ' + text : ''}`, [], localPath);
+        sendToC4('lark', chatId, msg, rejectReply);
+      } else {
+        const msg = formatMessage('p2p', senderName, '[image download failed]');
+        sendToC4('lark', chatId, msg, rejectReply);
+      }
+      return;
+    }
+
+    if (fileKey) {
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+      const localPath = path.join(MEDIA_DIR, `lark-${timestamp}-${fileName}`);
+      const result = await downloadFile(messageId, fileKey, localPath);
+      if (result.success) {
+        const msg = formatMessage('p2p', senderName, `[file: ${fileName}]`, [], localPath);
+        sendToC4('lark', chatId, msg, rejectReply);
+      } else {
+        const msg = formatMessage('p2p', senderName, `[file download failed: ${fileName}]`);
+        sendToC4('lark', chatId, msg, rejectReply);
+      }
+      return;
+    }
+
+    const msg = formatMessage('p2p', senderName, text);
+    sendToC4('lark', chatId, msg, rejectReply);
+    return;
+  }
+
+  // Group chat handling
+  if (chatType === 'group') {
+    const mentioned = isBotMentioned(mentions, botOpenId);
+    const isSmartGroup = (config.smart_groups || []).some(g => g.chat_id === chatId);
+    const allowedGroups = config.allowed_groups || [];
+    const whitelistEnabled = config.group_whitelist?.enabled !== false;
+    const isAllowedGroup = whitelistEnabled
+      ? allowedGroups.some(g => g.chat_id === chatId)
+      : true;
+
+    if (!isSmartGroup && !mentioned) {
+      console.log(`[lark] Group message without @mention, logged only`);
+      return;
+    }
+
+    if (!isSmartGroup) {
+      const senderIsOwner = isOwner(senderUserId, senderOpenId);
+
+      if (!isAllowedGroup && !senderIsOwner) {
+        console.log(`[lark] @mention in non-allowed group ${chatId}, ignoring`);
+        return;
+      }
+      if (!senderIsOwner && !isWhitelisted(senderUserId, senderOpenId)) {
+        console.log(`[lark] @mention from non-whitelisted user ${senderUserId} in group, ignoring`);
+        return;
+      }
+    }
+
+    console.log(`[lark] ${isSmartGroup ? 'Smart group' : 'Bot @mentioned in'} group ${chatId}`);
+    const contextMessages = getGroupContext(chatId, messageId);
+    updateCursor(chatId, messageId);
+
+    const senderName = await resolveUserName(senderUserId);
+    const cleanText = resolveMentions(text, mentions, { stripBot: true, botOpenId });
+    const groupRejectReply = (errMsg) => {
+      sendMessage(chatId, errMsg).catch(e => console.error('[lark] reject reply failed:', e.message));
+    };
+
+    if (imageKey) {
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+      const localPath = path.join(MEDIA_DIR, `lark-group-${timestamp}.png`);
+      const result = await downloadImage(messageId, imageKey, localPath);
+      if (result.success) {
+        const msg = formatMessage('group', senderName, `[image]${cleanText ? ' ' + cleanText : ''}`, contextMessages, localPath);
+        sendToC4('lark', chatId, msg, groupRejectReply);
+      }
+      return;
+    }
+
+    if (fileKey) {
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+      const localPath = path.join(MEDIA_DIR, `lark-group-${timestamp}-${fileName}`);
+      const result = await downloadFile(messageId, fileKey, localPath);
+      if (result.success) {
+        const msg = formatMessage('group', senderName, `[file: ${fileName}]${cleanText ? ' ' + cleanText : ''}`, contextMessages, localPath);
+        sendToC4('lark', chatId, msg, groupRejectReply);
+      }
+      return;
+    }
+
+    const msg = formatMessage('group', senderName, cleanText || text, contextMessages);
+    sendToC4('lark', chatId, msg, groupRejectReply);
+  }
+}
 
 // Health check
 app.get('/health', (req, res) => {
@@ -627,6 +653,14 @@ function shutdown() {
 
 process.on('SIGINT', shutdown);
 process.on('SIGTERM', shutdown);
+
+// Startup check: verification_token is required
+if (!config.bot?.verification_token) {
+  console.error('[lark] FATAL: bot.verification_token is not configured.');
+  console.error('[lark] Set it in ~/zylos/components/lark/config.json under bot.verification_token');
+  console.error('[lark] Find it in the developer console: Event Subscriptions → Verification Token');
+  process.exit(1);
+}
 
 // Fetch bot identity then start server
 const PORT = config.webhook_port || 3457;


### PR DESCRIPTION
## Summary

Combines PR #31 and PR #32 into a single PR for easier review.

### 1. Security: verification_token required
- **Startup gate**: service refuses to start without `bot.verification_token`
- **Runtime guard**: returns 500 if token somehow missing at request time
- **post-install.js**: prompts for token directly (no longer optional yes/no gate)
- **post-upgrade.js**: removed migration that was deleting `verification_token`
- **SKILL.md**: marked verification_token as REQUIRED in docs and next-steps

### 2. Webhook reliability: immediate HTTP 200 + message_id dedup
- `res.json({ code: 0 })` now sent **before** async message processing
- Prevents Lark ~15s timeout retry causing duplicate delivery
- `message_id` dedup Map with 5-min TTL (cleanup at 100 entries)
- Extracted `handleMessageEvent()` for clean async processing after response
- All `return res.json({ code: 0 })` replaced with plain `return`

## Files Changed

| File | Change |
|------|--------|
| `src/index.js` | Verification required + immediate response + dedup + handleMessageEvent extraction |
| `hooks/post-install.js` | Token prompt is now required (no optional gate) |
| `hooks/post-upgrade.js` | Removed migration that deleted verification_token |
| `SKILL.md` | Marked verification_token as REQUIRED |

## Test Plan

- [ ] Service refuses to start when `bot.verification_token` is missing
- [ ] Service starts normally when token is set
- [ ] Webhook rejects mismatched token (403)
- [ ] Single message processed once, HTTP 200 returned immediately
- [ ] Simulated retry (same message_id) returns 200 but skips processing
- [ ] Private chat, group @mention, smart group all still work
- [ ] Image/file download processed asynchronously after 200 response

Supersedes #31 and #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)