### PR TITLE
fix: default useMarkdownCard to false

### DIFF
--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -51,8 +51,7 @@ export const DEFAULT_CONFIG = {
   // Message settings
   message: {
     context_messages: 10,
-    // Send messages as interactive cards with markdown rendering (default: on)
-    useMarkdownCard: true
+    useMarkdownCard: false
   }
 };
 


### PR DESCRIPTION
## Summary
- Set `useMarkdownCard: false` in DEFAULT_CONFIG
- Markdown card rendering prevents bots from seeing rendered card message content from other bots
- Plain text is the safer default for bot-to-bot communication

## Test plan
- [ ] New installs get `useMarkdownCard: false` by default
- [ ] Existing installs with `useMarkdownCard: true` in config.json are unaffected (config file overrides defaults)

🤖 Generated with [Claude Code](https://claude.com/claude-code)