### PR TITLE
chore: bump version to 0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.9] - 2026-03-02
+
+### Security
+- Bump axios 1.13.4 → 1.13.6 (high: DoS via `__proto__` in mergeConfig) (#53)
+- Bump qs 6.14.1 → 6.14.2 (low: arrayLimit bypass in comma parsing) (#53)
+
+### Changed
+- Add release process guidelines to CLAUDE.md (#54)
+
 ## [0.1.8] - 2026-03-02
 
 ### Changed

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lark
-version: 0.1.8
+version: 0.1.9
 description: >-
   Lark (international) and Feishu (飞书, China) communication channel.
   Use when: (1) replying to Lark/Feishu messages (DM or group @mentions),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zylos-lark",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zylos-lark",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "MIT",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos-lark",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Lark and Feishu communication channel",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
## Summary
- Bump version to 0.1.9 for release

## Changes since v0.1.8
- fix: resolve dependabot security alerts — axios 1.13.6, qs 6.14.2 (#53)
- docs: add release process guidelines to CLAUDE.md (#54)

## Files updated
- package.json
- package-lock.json
- SKILL.md
- CHANGELOG.md