### PR TITLE
chore(release): prepare v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] - 2026-04-02
+
+### Fixed
+- Markdown-card auto-detection now preserves plain text replies as normal text messages while still rendering markdown content as interactive cards (#69)
+- Runtime config loading now preserves nested `message.useMarkdownCard` defaults for partial configs (#69)
+- Webhook message deduplication extracted into a dedicated helper with regression coverage for issue #68 (#70)
+
+### Security
+- Resolved the `path-to-regexp` audit alert in the Express dependency tree (#70)
+
 ## [0.2.1] - 2026-03-26
 
 ### Fixed

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lark
-version: 0.2.1
+version: 0.2.2
 description: >-
   Lark (international) and Feishu (飞书, China) communication channel.
   Use when: (1) replying to Lark/Feishu messages (DM or group @mentions),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zylos-lark",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zylos-lark",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "1.59.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos-lark",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Lark and Feishu communication channel",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
 ## Summary
  - bump package, lockfile, skill metadata, and changelog to 0.2.2
  - release fixes for markdown-card auto-detection and webhook dedup regression coverage
  - include the Express dependency-tree security fix for the path-to-regexp alert

  ## Testing
  - npm test
