### PR TITLE
fix: resolve sender names and @mention placeholders in CLI messages

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -164,7 +164,7 @@ async function main() {
         if (result.success && result.messages) {
           // Build sender name map from group members
           const nameMap = {};
-          const membersResult = await listChatMembers(args[1], 'user_id');
+          const membersResult = await listChatMembers(args[1], 'open_id');
           if (membersResult.success && membersResult.members) {
             membersResult.members.forEach(m => {
               if (m.memberId && m.name) nameMap[m.memberId] = m.name;

--- a/src/cli.js
+++ b/src/cli.js
@@ -162,10 +162,31 @@ async function main() {
 
         result = await listMessages(args[1], msgLimit, 'desc', startTime, endTime);
         if (result.success && result.messages) {
+          // Build sender name map from group members
+          const nameMap = {};
+          const membersResult = await listChatMembers(args[1], 'open_id');
+          if (membersResult.success && membersResult.members) {
+            membersResult.members.forEach(m => {
+              if (m.memberId && m.name) nameMap[m.memberId] = m.name;
+            });
+          }
+
           console.log(`Found ${result.messages.length} messages:\n`);
           result.messages.forEach(msg => {
             const time = new Date(msg.createTime).toLocaleString();
-            console.log(`[${time}] ${msg.sender}: ${msg.content}`);
+            const senderName = nameMap[msg.sender] || msg.sender;
+
+            // Replace @_user_N placeholders with real names from mentions
+            let content = msg.content;
+            if (msg.mentions && msg.mentions.length > 0) {
+              msg.mentions.forEach(m => {
+                if (m.key && m.name) {
+                  content = content.replaceAll(m.key, `@${m.name}`);
+                }
+              });
+            }
+
+            console.log(`[${time}] ${senderName}: ${content}`);
           });
           process.exit(0);
         }

--- a/src/cli.js
+++ b/src/cli.js
@@ -164,7 +164,7 @@ async function main() {
         if (result.success && result.messages) {
           // Build sender name map from group members
           const nameMap = {};
-          const membersResult = await listChatMembers(args[1], 'open_id');
+          const membersResult = await listChatMembers(args[1], 'user_id');
           if (membersResult.success && membersResult.members) {
             membersResult.members.forEach(m => {
               if (m.memberId && m.name) nameMap[m.memberId] = m.name;
@@ -319,7 +319,7 @@ async function main() {
           console.error('Usage: lark-cli members <chat_id>');
           process.exit(1);
         }
-        result = await listChatMembers(args[1]);
+        result = await listChatMembers(args[1], args[2] || 'user_id');
         if (result.success && result.members) {
           result.members.forEach(member => {
             console.log(`${member.memberId}  ${member.name || '(no name)'}`);

--- a/src/index.js
+++ b/src/index.js
@@ -416,7 +416,7 @@ async function preloadGroupMembers(chatId) {
   const normalizedChatId = chatId === undefined || chatId === null ? '' : String(chatId);
   if (!normalizedChatId || _preloadedGroups.has(normalizedChatId)) return;
   try {
-    const result = await listChatMembers(normalizedChatId);
+    const result = await listChatMembers(normalizedChatId, 'user_id');
     if (result.success && result.members) {
       const now = Date.now();
       let count = 0;

--- a/src/lib/message.js
+++ b/src/lib/message.js
@@ -147,7 +147,7 @@ export async function listMessages(chatId, limit = 20, sortType = 'desc', startT
       container_id: chatId,
       page_size: Math.min(limit, 50),
       sort_type: sortType === 'asc' ? 'ByCreateTimeAsc' : 'ByCreateTimeDesc',
-      user_id_type: 'user_id',
+      user_id_type: 'open_id',
     };
 
     if (startTime) params.start_time = String(startTime);

--- a/src/lib/message.js
+++ b/src/lib/message.js
@@ -147,7 +147,7 @@ export async function listMessages(chatId, limit = 20, sortType = 'desc', startT
       container_id: chatId,
       page_size: Math.min(limit, 50),
       sort_type: sortType === 'asc' ? 'ByCreateTimeAsc' : 'ByCreateTimeDesc',
-      user_id_type: 'open_id',
+      user_id_type: 'user_id',
     };
 
     if (startTime) params.start_time = String(startTime);


### PR DESCRIPTION
## Summary
- Unify all user ID handling on `user_id` format (instead of mixed `open_id`/`user_id`)
- CLI `messages` command now resolves sender IDs to real names via group member lookup
- Replaces `@_user_N` placeholders in message content with actual names from mentions array
- `preloadGroupMembers` (webhook path) explicitly uses `user_id` (fixes #73)
- CLI `members` command defaults to `user_id`

**Before:** `[4/13/2026] ou_cd42ae...: @_user_1 hello`
**After:** `[4/13/2026] howard.zhou: @zylos01 hello`

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)