### PR TITLE
fix: log card content preview when extractInteractiveText falls back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.4] - 2026-04-20
+
+### Changed
+- `extractInteractiveText` now logs a truncated preview of the card content JSON whenever it falls back to `[interactive message]` (either because the schema is unrecognized or a parse error was caught). This makes it easier to identify new card schemas that the parser does not yet handle, so they can be added in follow-up PRs.
+
 ## [0.2.3] - 2026-04-13
 
 ### Fixed

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lark
-version: 0.2.3
+version: 0.2.4
 description: >-
   Lark (international) and Feishu (飞书, China) communication channel.
   Use when: (1) replying to Lark/Feishu messages (DM or group @mentions),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zylos-lark",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zylos-lark",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "1.59.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos-lark",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Lark and Feishu communication channel",
   "type": "module",
   "main": "src/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -1011,9 +1011,17 @@ function extractInteractiveText(content) {
     // original cards have header.title.content
     const title = content?.title || content?.header?.title?.content;
     if (title) return `[card] ${title}`;
-  } catch {
-    // Fall through
+  } catch (err) {
+    try {
+      const preview = JSON.stringify(content).slice(0, 2000);
+      console.log(`[lark] extractInteractiveText threw (${err.message}); content preview: ${preview}`);
+    } catch { /* unable to stringify */ }
+    return '[interactive message]';
   }
+  try {
+    const preview = JSON.stringify(content).slice(0, 2000);
+    console.log(`[lark] extractInteractiveText: unrecognized card schema, content preview: ${preview}`);
+  } catch { /* unable to stringify */ }
   return '[interactive message]';
 }
 


### PR DESCRIPTION
When `extractInteractiveText` cannot identify any text from a card (neither Schema 2.0 `body.elements[]`, legacy `elements[]`, nor title fallback match, or a parse error is thrown), it returns the placeholder `[interactive message]` with no indication of what the card actually contained. That placeholder propagates into `<replying-to>` blocks delivered to the agent, so the agent has no way to answer questions about the quoted card and no one knows which schema is missing from the parser.

Add a `console.log` at the fallback points that dumps a 2000-char preview of the card JSON, so unrecognized schemas surface in the service logs and can be added in follow-up PRs.

Bumps version to 0.2.4.

## Summary

<!-- Brief description of the changes -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist

- [ ] Code follows the project's ESM-only style
- [ ] Self-review completed
- [ ] Changes are tested locally
- [ ] CHANGELOG.md updated (if applicable)
- [ ] No secrets or internal references included
