### PR TITLE
feat: Lark API compatibility fixes and enhanced message handling

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -396,7 +396,7 @@ Groups are stored in a map keyed by `chat_id`:
 ```
 
 - `mode`: `"mention"` (respond to @mentions only) or `"smart"` (receive all messages)
-- `allowFrom`: Optional list of user_id/open_id. Empty = all group members allowed. `"*"` = wildcard.
+- `allowFrom`: Optional list of user_id/open_id/app_id. Empty = all group members allowed. `"*"` = wildcard. App IDs (`cli_xxx`) allow trusted bot-to-bot @mentions; the bot always ignores its own app_id to prevent loops.
 - `historyLimit`: Optional per-group context message limit (overrides `message.context_messages`)
 
 ### Markdown Card

--- a/scripts/send.js
+++ b/scripts/send.js
@@ -20,6 +20,7 @@ dotenv.config({ path: path.join(process.env.HOME, 'zylos/.env') });
 import { getConfig, DATA_DIR } from '../src/lib/config.js';
 import { hasMarkdownContent } from '../src/lib/markdown.js';
 import { sendToGroup, sendMessage, uploadImage, sendImage, uploadFile, sendFile, replyToMessage, sendMarkdownCard, replyMarkdownCard } from '../src/lib/message.js';
+import { resolveOutgoingMentions } from '../src/lib/mention.js';
 
 const TYPING_DIR = path.join(DATA_DIR, 'typing');
 const MENTION_REGISTRY_PATH = path.join(DATA_DIR, 'mention-registry.json');
@@ -36,29 +37,6 @@ function loadMentionRegistry() {
   } catch {
     return {};
   }
-}
-
-/**
- * Resolve @username mentions in text to Lark <at> tags for text messages.
- * Only matches @username at word boundaries (not inside URLs or email addresses).
- * Returns { resolved: string, hasMentions: boolean }
- */
-function resolveMentions(text) {
-  const registry = loadMentionRegistry();
-  const names = Object.keys(registry).sort((a, b) => b.length - a.length);
-  if (names.length === 0) return { resolved: text, hasMentions: false };
-
-  let resolved = text;
-  let hasMentions = false;
-  for (const name of names) {
-    const pattern = new RegExp(`@${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?=\\s|$|[，。！？,.:;)]|\\n)`, 'g');
-    if (pattern.test(resolved)) {
-      hasMentions = true;
-      const entry = registry[name];
-      resolved = resolved.replace(pattern, `<at user_id="${entry.open_id}">${name}</at>`);
-    }
-  }
-  return { resolved, hasMentions };
 }
 
 // Parse arguments
@@ -237,7 +215,7 @@ async function sendCardChunk(chunk, isFirstChunk) {
  * Reply failures fall back to sendMessage (DM) or sendToGroup (group).
  */
 async function sendText(endpoint, text) {
-  const { resolved, hasMentions } = resolveMentions(text);
+  const { resolved, hasMentions } = resolveOutgoingMentions(text, loadMentionRegistry());
   // Cards don't support <at> tags — force text mode when mentions are present
   const useCard = !hasMentions && config.message?.useMarkdownCard && hasMarkdownContent(text);
   const maxLen = useCard ? CARD_MAX_LENGTH : MAX_LENGTH;

--- a/scripts/send.js
+++ b/scripts/send.js
@@ -22,8 +22,44 @@ import { hasMarkdownContent } from '../src/lib/markdown.js';
 import { sendToGroup, sendMessage, uploadImage, sendImage, uploadFile, sendFile, replyToMessage, sendMarkdownCard, replyMarkdownCard } from '../src/lib/message.js';
 
 const TYPING_DIR = path.join(DATA_DIR, 'typing');
+const MENTION_REGISTRY_PATH = path.join(DATA_DIR, 'mention-registry.json');
 
 const MAX_LENGTH = 2000;  // Lark message max length
+
+/**
+ * Load mention registry: maps display names to Lark open_ids.
+ * Registry is auto-populated from incoming webhook events and can be manually edited.
+ */
+function loadMentionRegistry() {
+  try {
+    return JSON.parse(fs.readFileSync(MENTION_REGISTRY_PATH, 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Resolve @username mentions in text to Lark <at> tags for text messages.
+ * Only matches @username at word boundaries (not inside URLs or email addresses).
+ * Returns { resolved: string, hasMentions: boolean }
+ */
+function resolveMentions(text) {
+  const registry = loadMentionRegistry();
+  const names = Object.keys(registry).sort((a, b) => b.length - a.length);
+  if (names.length === 0) return { resolved: text, hasMentions: false };
+
+  let resolved = text;
+  let hasMentions = false;
+  for (const name of names) {
+    const pattern = new RegExp(`@${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?=\\s|$|[，。！？,.:;)]|\\n)`, 'g');
+    if (pattern.test(resolved)) {
+      hasMentions = true;
+      const entry = registry[name];
+      resolved = resolved.replace(pattern, `<at user_id="${entry.open_id}">${name}</at>`);
+    }
+  }
+  return { resolved, hasMentions };
+}
 
 // Parse arguments
 const args = process.argv.slice(2);
@@ -201,9 +237,11 @@ async function sendCardChunk(chunk, isFirstChunk) {
  * Reply failures fall back to sendMessage (DM) or sendToGroup (group).
  */
 async function sendText(endpoint, text) {
-  const useCard = config.message?.useMarkdownCard && hasMarkdownContent(text);
+  const { resolved, hasMentions } = resolveMentions(text);
+  // Cards don't support <at> tags — force text mode when mentions are present
+  const useCard = !hasMentions && config.message?.useMarkdownCard && hasMarkdownContent(text);
   const maxLen = useCard ? CARD_MAX_LENGTH : MAX_LENGTH;
-  const chunks = splitMessage(text, maxLen);
+  const chunks = splitMessage(useCard ? text : resolved, maxLen);
   const { chatId, root, parent, msg, type } = parsedEndpoint;
   const isDM = type === 'p2p';
   const isGroup = type === 'group';

--- a/src/index.js
+++ b/src/index.js
@@ -653,7 +653,7 @@ function isSmartGroup(chatId) {
   return (config.smart_groups || []).some(g => String(g.chat_id) === normalizedChatId);
 }
 
-function isSenderAllowedInGroup(chatId, senderUserId, senderOpenId) {
+function isSenderAllowedInGroup(chatId, senderUserId, senderOpenId, senderAppId) {
   const groupConfig = resolveGroupConfig(chatId);
   if (!groupConfig?.allowFrom || groupConfig.allowFrom.length === 0) {
     return true;
@@ -661,9 +661,11 @@ function isSenderAllowedInGroup(chatId, senderUserId, senderOpenId) {
   const allowed = groupConfig.allowFrom.map(s => String(s).toLowerCase());
   const normalizedSenderUserId = senderUserId === undefined || senderUserId === null ? '' : String(senderUserId).toLowerCase();
   const normalizedSenderOpenId = senderOpenId === undefined || senderOpenId === null ? '' : String(senderOpenId).toLowerCase();
+  const normalizedSenderAppId = senderAppId === undefined || senderAppId === null ? '' : String(senderAppId).toLowerCase();
   if (allowed.includes('*')) return true;
   if (normalizedSenderUserId && allowed.includes(normalizedSenderUserId)) return true;
   if (normalizedSenderOpenId && allowed.includes(normalizedSenderOpenId)) return true;
+  if (normalizedSenderAppId && allowed.includes(normalizedSenderAppId)) return true;
   return false;
 }
 
@@ -682,13 +684,17 @@ function getGroupName(chatId) {
   return String(chatId || 'unknown');
 }
 
-// Check if bot is mentioned
-function isBotMentioned(mentions, botId) {
+// Check if bot is mentioned. Lark may identify bot mentions by open_id or app_id.
+function isBotMentioned(mentions, botOpenId, botAppId = '') {
   if (!mentions || !Array.isArray(mentions)) return false;
-  const normalizedBotId = botId === undefined || botId === null ? '' : String(botId);
+  const normalizedBotOpenId = botOpenId === undefined || botOpenId === null ? '' : String(botOpenId);
+  const normalizedBotAppId = botAppId === undefined || botAppId === null ? '' : String(botAppId);
   return mentions.some(m => {
     const mentionId = m.id?.open_id || m.id?.user_id || m.id?.app_id || '';
-    return (normalizedBotId && String(mentionId) === normalizedBotId) || m.key === '@_all';
+    const normalizedMentionId = String(mentionId);
+    return (normalizedBotOpenId && normalizedMentionId === normalizedBotOpenId) ||
+      (normalizedBotAppId && normalizedMentionId === normalizedBotAppId) ||
+      m.key === '@_all';
   });
 }
 
@@ -1237,6 +1243,7 @@ async function handleMessageEvent(event) {
 
   const senderUserId = sender.sender_id?.user_id;
   const senderOpenId = sender.sender_id?.open_id;
+  const senderAppId = sender.sender_id?.app_id;
   const chatId = message.chat_id;
   const messageId = message.message_id;
   const chatType = message.chat_type;
@@ -1252,7 +1259,8 @@ async function handleMessageEvent(event) {
     text = await fetchMergeForwardContent(messageId);
   }
 
-  console.log(`[lark] ${chatType} message from ${senderUserId}: ${(text || '').substring(0, 50) || '[media]'}...`);
+  const senderLogId = senderUserId || senderOpenId || senderAppId || 'unknown';
+  console.log(`[lark] ${chatType} message from ${senderLogId}: ${(text || '').substring(0, 50) || '[media]'}...`);
 
   // Build log text with file/image metadata
   let logText = text;
@@ -1402,14 +1410,19 @@ async function handleMessageEvent(event) {
 
   // Group chat handling
   if (chatType === 'group') {
-    const mentioned = isBotMentioned(mentions, botOpenId);
+    const mentioned = isBotMentioned(mentions, botOpenId, botAppId);
     const senderIsOwner = isOwner(senderUserId, senderOpenId);
+    const senderIsSelfApp = senderAppId && botAppId && String(senderAppId) === String(botAppId);
+    if (senderIsSelfApp) {
+      console.log(`[lark] Ignoring own app message ${messageId} from ${senderAppId}`);
+      return;
+    }
     const groupPolicy = config.groupPolicy || 'allowlist';
     if (groupPolicy === 'disabled') {
       if (mentioned) {
         replyToMessage(messageId, "Sorry, group chat is currently disabled.").catch(() => {});
       }
-      console.log(`[lark] Group policy disabled, ignoring group message from ${senderUserId}`);
+      console.log(`[lark] Group policy disabled, ignoring group message from ${senderLogId}`);
       return;
     }
     const allowedGroup = isGroupAllowed(chatId);
@@ -1425,12 +1438,12 @@ async function handleMessageEvent(event) {
       return;
     }
 
-    if (!isSenderAllowedInGroup(chatId, senderUserId, senderOpenId) && !senderIsOwner) {
+    if (!isSenderAllowedInGroup(chatId, senderUserId, senderOpenId, senderAppId) && !senderIsOwner) {
       if (mentioned) {
-        console.log(`[lark] Sender ${senderUserId} not in group ${chatId} allowFrom, rejecting`);
+        console.log(`[lark] Sender ${senderLogId} not in group ${chatId} allowFrom, rejecting`);
         replyToMessage(messageId, "Sorry, you don't have permission to interact with me in this group.").catch(() => {});
       } else {
-        console.log(`[lark] Sender ${senderUserId} not in group ${chatId} allowFrom, ignoring`);
+        console.log(`[lark] Sender ${senderLogId} not in group ${chatId} allowFrom, ignoring`);
       }
       return;
     }

--- a/src/index.js
+++ b/src/index.js
@@ -693,6 +693,28 @@ function isBotMentioned(mentions, botId) {
 }
 
 /**
+ * Auto-populate mention registry from incoming webhook mention data.
+ * Maps display names to Lark open_ids for outgoing @mention support.
+ */
+function updateMentionRegistry(mentions) {
+  if (!mentions || !Array.isArray(mentions) || mentions.length === 0) return;
+  const registryPath = path.join(DATA_DIR, 'mention-registry.json');
+  let registry = {};
+  try { registry = JSON.parse(fs.readFileSync(registryPath, 'utf8')); } catch {}
+  let changed = false;
+  for (const m of mentions) {
+    if (!m.name || !m.id?.open_id) continue;
+    if (!registry[m.name] || registry[m.name].open_id !== m.id.open_id) {
+      registry[m.name] = { open_id: m.id.open_id, type: m.mentioned_type || 'user' };
+      changed = true;
+    }
+  }
+  if (changed) {
+    try { fs.writeFileSync(registryPath, JSON.stringify(registry, null, 2) + '\n'); } catch {}
+  }
+}
+
+/**
  * Resolve @_user_N placeholders in message text to real names.
  */
 function resolveMentions(text, mentions, { stripBot = false, botOpenId: botId } = {}) {
@@ -808,6 +830,7 @@ async function fetchQuotedMessage(messageId) {
     const client = getClient();
     const res = await client.im.message.get({
       path: { message_id: messageId },
+      params: { card_msg_content_type: 'user_card_content' },
     });
     if (res.code === 0 && res.data?.items?.[0]) {
       const msg = res.data.items[0];
@@ -833,6 +856,77 @@ async function fetchQuotedMessage(messageId) {
     console.log(`[lark] Failed to fetch quoted message ${messageId}: ${err.message}`);
   }
   return null;
+}
+
+/**
+ * Fetch sub-messages from a merge_forward message via im.message.get.
+ * The response items[] contains 1 parent (merge_forward) + N sub-messages.
+ * Sub-messages have upper_message_id pointing to the parent.
+ * Note: resource files (images/files) in sub-messages cannot be downloaded per Lark API limitation.
+ */
+async function fetchMergeForwardContent(messageId) {
+  try {
+    const { getClient } = await import('./lib/client.js');
+    const client = getClient();
+    const res = await client.im.message.get({
+      path: { message_id: messageId },
+    });
+    if (res.code !== 0 || !res.data?.items || res.data.items.length <= 1) {
+      return '[合并转发消息，子消息获取失败]';
+    }
+
+    // Build a name map from mentions across all sub-messages
+    const mentionNames = new Map();
+    for (const msg of res.data.items) {
+      for (const m of (msg.mentions || [])) {
+        if (m.id && m.name) mentionNames.set(m.id, m.name);
+      }
+    }
+
+    const lines = [];
+    for (const msg of res.data.items) {
+      if (msg.msg_type === 'merge_forward') continue;
+
+      const senderId = msg.sender?.id;
+      const senderName = mentionNames.get(senderId) || await resolveUserName(senderId);
+      let content;
+      try {
+        content = JSON.parse(msg.body?.content || '{}');
+      } catch {
+        content = {};
+      }
+
+      let text;
+      if (msg.msg_type === 'text') {
+        text = content.text || '';
+      } else if (msg.msg_type === 'post') {
+        ({ text } = extractPostText(content.content || [], msg.message_id));
+      } else if (msg.msg_type === 'interactive') {
+        text = extractInteractiveText(content);
+      } else if (msg.msg_type === 'image') {
+        text = '[图片]';
+      } else if (msg.msg_type === 'file') {
+        text = `[文件: ${content.file_name || 'unknown'}]`;
+      } else if (msg.msg_type === 'audio') {
+        text = '[语音]';
+      } else {
+        text = `[${msg.msg_type}]`;
+      }
+
+      if (msg.mentions && msg.mentions.length > 0) {
+        text = resolveMentions(text, msg.mentions);
+      }
+
+      const ts = msg.create_time ? new Date(parseInt(msg.create_time)).toISOString().replace('T', ' ').replace(/\.\d+Z$/, '') : '';
+      lines.push(`${senderName} (${ts}): ${text}`);
+    }
+
+    if (lines.length === 0) return '[合并转发消息，无可读内容]';
+    return `[合并转发消息，共 ${lines.length} 条]:\n${lines.join('\n')}`;
+  } catch (err) {
+    console.error(`[lark] Failed to fetch merge_forward content for ${messageId}: ${err.message}`);
+    return '[合并转发消息，子消息获取失败]';
+  }
 }
 
 /**
@@ -1028,6 +1122,11 @@ function extractInteractiveText(content) {
 // Returns imageKeys as array (all images from post messages, or single image)
 function extractMessageContent(message) {
   const msgType = message.message_type;
+
+  if (msgType === 'merge_forward') {
+    return { text: '', imageKeys: [], fileKey: null, fileName: null, audioKey: null, isMergeForward: true };
+  }
+
   let content;
   try {
     content = JSON.parse(message.content || '{}');
@@ -1132,7 +1231,9 @@ async function handleMessageEvent(event) {
   }
   const message = event.event.message;
   const sender = event.event.sender;
+
   const mentions = message.mentions;
+  updateMentionRegistry(mentions);
 
   const senderUserId = sender.sender_id?.user_id;
   const senderOpenId = sender.sender_id?.open_id;
@@ -1145,7 +1246,12 @@ async function handleMessageEvent(event) {
 
   // Dedup is already checked in the webhook handler (line ~1013)
 
-  const { text, imageKeys, fileKey, fileName, audioKey } = extractMessageContent(message);
+  let { text, imageKeys, fileKey, fileName, audioKey, isMergeForward } = extractMessageContent(message);
+
+  if (isMergeForward) {
+    text = await fetchMergeForwardContent(messageId);
+  }
+
   console.log(`[lark] ${chatType} message from ${senderUserId}: ${(text || '').substring(0, 50) || '[media]'}...`);
 
   // Build log text with file/image metadata

--- a/src/index.js
+++ b/src/index.js
@@ -1410,13 +1410,13 @@ async function handleMessageEvent(event) {
 
   // Group chat handling
   if (chatType === 'group') {
-    const mentioned = isBotMentioned(mentions, botOpenId, botAppId);
-    const senderIsOwner = isOwner(senderUserId, senderOpenId);
     const senderIsSelfApp = senderAppId && botAppId && String(senderAppId) === String(botAppId);
     if (senderIsSelfApp) {
       console.log(`[lark] Ignoring own app message ${messageId} from ${senderAppId}`);
       return;
     }
+    const mentioned = isBotMentioned(mentions, botOpenId, botAppId);
+    const senderIsOwner = isOwner(senderUserId, senderOpenId);
     const groupPolicy = config.groupPolicy || 'allowlist';
     if (groupPolicy === 'disabled') {
       if (mentioned) {

--- a/src/lib/mention.js
+++ b/src/lib/mention.js
@@ -1,0 +1,28 @@
+/**
+ * Helpers for preserving outgoing Lark @mentions.
+ */
+
+const LARK_AT_TAG_RE = /<at\s+user_id=(["'])(?:ou_[^"']+|all)\1[^>]*>/i;
+
+export function hasLarkAtTag(text) {
+  return LARK_AT_TAG_RE.test(text || '');
+}
+
+export function resolveOutgoingMentions(text, registry = {}) {
+  const names = Object.keys(registry).sort((a, b) => b.length - a.length);
+  let resolved = text;
+  let hasMentions = hasLarkAtTag(text);
+
+  for (const name of names) {
+    const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const pattern = new RegExp(`@${escapedName}(?=\\s|$|[，。！？,.:;)]|\\n)`, 'g');
+    if (pattern.test(resolved)) {
+      const entry = registry[name];
+      if (!entry?.open_id) continue;
+      hasMentions = true;
+      resolved = resolved.replace(pattern, `<at user_id="${entry.open_id}">${name}</at>`);
+    }
+  }
+
+  return { resolved, hasMentions };
+}

--- a/src/lib/message.js
+++ b/src/lib/message.js
@@ -148,6 +148,7 @@ export async function listMessages(chatId, limit = 20, sortType = 'desc', startT
       page_size: Math.min(limit, 50),
       sort_type: sortType === 'asc' ? 'ByCreateTimeAsc' : 'ByCreateTimeDesc',
       user_id_type: 'open_id',
+      card_msg_content_type: 'user_card_content',
     };
 
     if (startTime) params.start_time = String(startTime);
@@ -339,7 +340,7 @@ export async function uploadFile(filePath, fileType = 'stream') {
   const client = getClient();
 
   try {
-    const fileData = fs.readFileSync(filePath);
+    const fileData = Buffer.from(fs.readFileSync(filePath));
     const fileName = path.basename(filePath);
 
     const res = await client.im.file.create({
@@ -350,10 +351,11 @@ export async function uploadFile(filePath, fileType = 'stream') {
       },
     });
 
-    if (res.code === 0) {
-      return { success: true, fileKey: res.data.file_key, message: 'File uploaded successfully' };
+    const fileKey = res?.file_key ?? res?.data?.file_key;
+    if (fileKey) {
+      return { success: true, fileKey, message: 'File uploaded successfully' };
     } else {
-      return { success: false, message: `Failed to upload file: ${res.msg}`, code: res.code };
+      return { success: false, message: `Failed to upload file: ${res?.msg}`, code: res?.code };
     }
   } catch (err) {
     return { success: false, message: err.message };

--- a/test/group-access.test.js
+++ b/test/group-access.test.js
@@ -1,0 +1,47 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+function isSenderAllowed(allowFrom, senderUserId, senderOpenId, senderAppId) {
+  if (!allowFrom || allowFrom.length === 0) return true;
+  const allowed = allowFrom.map(s => String(s).toLowerCase());
+  const normalizedSenderUserId = senderUserId === undefined || senderUserId === null ? '' : String(senderUserId).toLowerCase();
+  const normalizedSenderOpenId = senderOpenId === undefined || senderOpenId === null ? '' : String(senderOpenId).toLowerCase();
+  const normalizedSenderAppId = senderAppId === undefined || senderAppId === null ? '' : String(senderAppId).toLowerCase();
+  if (allowed.includes('*')) return true;
+  if (normalizedSenderUserId && allowed.includes(normalizedSenderUserId)) return true;
+  if (normalizedSenderOpenId && allowed.includes(normalizedSenderOpenId)) return true;
+  if (normalizedSenderAppId && allowed.includes(normalizedSenderAppId)) return true;
+  return false;
+}
+
+test('group allowFrom can match app sender ids for bot-to-bot mentions', () => {
+  assert.equal(isSenderAllowed(['cli_sender_bot'], null, null, 'cli_sender_bot'), true);
+  assert.equal(isSenderAllowed(['CLI_SENDER_BOT'], null, null, 'cli_sender_bot'), true);
+  assert.equal(isSenderAllowed(['ou_human'], null, null, 'cli_sender_bot'), false);
+});
+
+test('group allowFrom still matches user and open ids', () => {
+  assert.equal(isSenderAllowed(['user_123'], 'user_123', 'ou_abc', null), true);
+  assert.equal(isSenderAllowed(['ou_abc'], 'user_123', 'ou_abc', null), true);
+  assert.equal(isSenderAllowed(['*'], null, null, 'cli_sender_bot'), true);
+});
+
+function isMentioned(mentions, botOpenId, botAppId = '') {
+  if (!mentions || !Array.isArray(mentions)) return false;
+  const normalizedBotOpenId = botOpenId === undefined || botOpenId === null ? '' : String(botOpenId);
+  const normalizedBotAppId = botAppId === undefined || botAppId === null ? '' : String(botAppId);
+  return mentions.some(m => {
+    const mentionId = m.id?.open_id || m.id?.user_id || m.id?.app_id || '';
+    const normalizedMentionId = String(mentionId);
+    return (normalizedBotOpenId && normalizedMentionId === normalizedBotOpenId) ||
+      (normalizedBotAppId && normalizedMentionId === normalizedBotAppId) ||
+      m.key === '@_all';
+  });
+}
+
+test('bot mention detection matches open_id and app_id mentions', () => {
+  assert.equal(isMentioned([{ id: { open_id: 'ou_bot' } }], 'ou_bot', 'cli_bot'), true);
+  assert.equal(isMentioned([{ id: { app_id: 'cli_bot' } }], 'ou_bot', 'cli_bot'), true);
+  assert.equal(isMentioned([{ key: '@_all', id: {} }], 'ou_bot', 'cli_bot'), true);
+  assert.equal(isMentioned([{ id: { app_id: 'cli_other' } }], 'ou_bot', 'cli_bot'), false);
+});

--- a/test/mention.test.js
+++ b/test/mention.test.js
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { hasLarkAtTag, resolveOutgoingMentions } from '../src/lib/mention.js';
+
+test('detects existing Lark at tags', () => {
+  assert.equal(hasLarkAtTag('<at user_id="ou_123">zylos101</at> review done'), true);
+  assert.equal(hasLarkAtTag('<at user_id="all"></at> deploy notice'), true);
+  assert.equal(hasLarkAtTag('&lt;at user_id="ou_123"&gt;zylos101&lt;/at&gt;'), false);
+  assert.equal(hasLarkAtTag('@zylos101 review done'), false);
+});
+
+test('resolves registry mentions to Lark at tags', () => {
+  const result = resolveOutgoingMentions('cc @zylos101 review done', {
+    zylos101: { open_id: 'ou_75577b719ba124bf7dec9f93f9e86763' },
+  });
+
+  assert.equal(result.hasMentions, true);
+  assert.equal(
+    result.resolved,
+    'cc <at user_id="ou_75577b719ba124bf7dec9f93f9e86763">zylos101</at> review done'
+  );
+});
+
+test('treats existing at tags as mentions even without registry entries', () => {
+  const source = [
+    '<at user_id="ou_75577b719ba124bf7dec9f93f9e86763">zylos101</at> re-review 完成。',
+    '',
+    '- `git diff --check` passed',
+  ].join('\n');
+
+  const result = resolveOutgoingMentions(source, {});
+
+  assert.equal(result.hasMentions, true);
+  assert.equal(result.resolved, source);
+});


### PR DESCRIPTION
## Summary
- **merge_forward parsing**: Parse sub-messages from forwarded message bundles via `im.message.get` — SDK doesn't natively handle `merge_forward` msg_type
- **@mention registry**: Auto-capture `open_id` from incoming webhooks, resolve `@name` to Lark `<at>` tags in outgoing messages, force text mode when mentions present (cards don't support `<at>`)
- **API response compatibility**: `card_msg_content_type` param for card content retrieval, `Buffer.from()` for upload reliability, defensive `file_key` access across API versions

## Context
These are production-tested fixes running on zylos101 since 2026-05-26. Extracted from local modifications during the 0.2.3 → 0.3.1 upgrade cycle.

## Files changed
- `scripts/send.js` (+40 lines) — @mention resolution in outgoing messages
- `src/index.js` (+108 lines) — merge_forward fetcher + mention registry auto-capture
- `src/lib/message.js` (+3 changes) — API compatibility fixes

## Test plan
- [x] merge_forward: Verified with real forwarded messages in Lark groups
- [x] @mention: Verified outgoing @mentions resolve to real notifications
- [x] uploadFile: Verified file uploads work with Buffer.from() wrapper
- [x] card_msg_content_type: Verified card message content is no longer empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)