### PR TITLE
fix: honor falsy Domain.Feishu so feishu configs don't fall through to Lark International

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Feishu (China) configs no longer fall through to Lark International.**
+  `lark.Domain.Feishu === 0` is a falsy enum value, so the previous
+  `DOMAIN_MAP[domain] || lark.Domain.Lark` fallback silently resolved a
+  `"domain": "feishu"` config to the Lark International endpoint. This
+  pointed Feishu credentials at `larksuite.com`, which the WebSocket long
+  connection rejects with `code: 1000040351, system busy`, and routed REST
+  API calls to the wrong region. Domain resolution is now centralized in
+  `src/lib/domain.js` (`resolveDomain`) using an explicit key-presence check,
+  so a known-but-falsy value is honored. Affects both the WebSocket transport
+  and the REST client.
+
 ## [0.3.1] - 2026-05-27
 
 ### Security

--- a/src/lib/client.js
+++ b/src/lib/client.js
@@ -9,11 +9,7 @@
 
 import * as lark from '@larksuiteoapi/node-sdk';
 import { getCredentials, getConfig } from './config.js';
-
-const DOMAIN_MAP = {
-  feishu: lark.Domain.Feishu,
-  lark: lark.Domain.Lark,
-};
+import { resolveDomain } from './domain.js';
 
 let clientInstance = null;
 
@@ -41,7 +37,7 @@ export function getClient() {
     appId: creds.app_id,
     appSecret: creds.app_secret,
     appType: lark.AppType.SelfBuild,
-    domain: DOMAIN_MAP[cfg.domain] || lark.Domain.Lark,
+    domain: resolveDomain(cfg.domain),
   });
 
   return clientInstance;

--- a/src/lib/domain.js
+++ b/src/lib/domain.js
@@ -1,0 +1,28 @@
+/**
+ * Domain resolution for Lark (international) vs Feishu (China).
+ *
+ * IMPORTANT: `lark.Domain.Feishu === 0` is a *falsy* enum value, so a naive
+ * `DOMAIN_MAP[key] || lark.Domain.Lark` fallback silently falls through to
+ * Lark International for `feishu` configs. That points Feishu credentials at
+ * the larksuite.com endpoint, which the WebSocket long connection rejects with
+ * `code: 1000040351, system busy`. Use an explicit key-presence check instead.
+ */
+
+import * as lark from '@larksuiteoapi/node-sdk';
+
+export const DOMAIN_MAP = {
+  feishu: lark.Domain.Feishu,
+  lark: lark.Domain.Lark,
+};
+
+/**
+ * Resolve a config domain key to the SDK Domain value.
+ * Falls back to Lark International only for unknown/missing keys — a known key
+ * whose value is falsy (e.g. `feishu` → 0) is honored, not overridden.
+ *
+ * @param {string} domainKey - 'feishu' | 'lark'
+ * @returns {string|number} lark.Domain value
+ */
+export function resolveDomain(domainKey) {
+  return domainKey in DOMAIN_MAP ? DOMAIN_MAP[domainKey] : lark.Domain.Lark;
+}

--- a/src/lib/transport/websocket.js
+++ b/src/lib/transport/websocket.js
@@ -10,11 +10,7 @@
  */
 
 import * as lark from '@larksuiteoapi/node-sdk';
-
-const DOMAIN_MAP = {
-  feishu: lark.Domain.Feishu,
-  lark: lark.Domain.Lark,
-};
+import { resolveDomain } from '../domain.js';
 
 let wsClient = null;
 let connectionState = {
@@ -30,7 +26,7 @@ let connectionState = {
  * @param {function} isDuplicate - dedup check function from index.js
  */
 export async function startWebSocket(config, credentials, handleMessageEvent, isDuplicate) {
-  const domain = DOMAIN_MAP[config.domain] || lark.Domain.Lark;
+  const domain = resolveDomain(config.domain);
 
   const eventDispatcher = new lark.EventDispatcher({}).register({
     'im.message.receive_v1': async (data) => {

--- a/test/domain.test.js
+++ b/test/domain.test.js
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import * as lark from '@larksuiteoapi/node-sdk';
+import { resolveDomain } from '../src/lib/domain.js';
+
+// Regression for the falsy-fallthrough bug: lark.Domain.Feishu === 0, so
+// `DOMAIN_MAP[key] || lark.Domain.Lark` wrongly resolved 'feishu' to Lark
+// International, causing WebSocket `code: 1000040351, system busy`.
+test("'feishu' resolves to Domain.Feishu even though it is falsy (0)", () => {
+  assert.equal(lark.Domain.Feishu, 0, 'precondition: Feishu enum is falsy');
+  assert.equal(resolveDomain('feishu'), lark.Domain.Feishu);
+});
+
+test("'lark' resolves to Domain.Lark", () => {
+  assert.equal(resolveDomain('lark'), lark.Domain.Lark);
+});
+
+test('unknown or missing keys fall back to Lark International', () => {
+  assert.equal(resolveDomain('nope'), lark.Domain.Lark);
+  assert.equal(resolveDomain(undefined), lark.Domain.Lark);
+  assert.equal(resolveDomain(''), lark.Domain.Lark);
+});


### PR DESCRIPTION
## Problem

`"domain": "feishu"` configs silently connect to **Lark International** (`open.larksuite.com`) instead of Feishu (`open.feishu.cn`).

Root cause: `lark.Domain.Feishu === 0` — a *falsy* enum value — so the domain resolver `DOMAIN_MAP[domain] || lark.Domain.Lark` evaluates `0 || Domain.Lark` and falls through to Lark International. The consequences for a Feishu (China) self-build app:

- The **WebSocket long connection** is rejected with `code: 1000040351, system busy` and never receives events (`unable to connect to the server after trying N times`).
- The **REST API client** sends calls to the wrong region.

This affects every Feishu deployment using the WebSocket transport (added in #63). It bit a production deployment after an upgrade reset a local workaround.

## Fix

Centralize domain resolution in a new `src/lib/domain.js` and resolve via an explicit key-presence check so a known-but-falsy enum value is honored:

```js
export function resolveDomain(domainKey) {
  return domainKey in DOMAIN_MAP ? DOMAIN_MAP[domainKey] : lark.Domain.Lark;
}
```

- `src/lib/transport/websocket.js` and `src/lib/client.js` now use `resolveDomain()` and no longer duplicate `DOMAIN_MAP`.
- Unknown/missing domain keys still fall back to Lark International (unchanged behavior).
- Added `test/domain.test.js` regression test (asserts `feishu` → `Domain.Feishu` `0`).

## Testing

`node --test` — 16/16 pass (3 new domain tests + existing suite).

## Changelog

Added an `[Unreleased] / Fixed` entry; left the version bump for maintainers per the documented release process.
