### PR TITLE
fix(lark): extract markdown body from interactive cards via user_dsl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2026-06-09
+
+### Fixed
+- **Interactive (markdown) cards now resolve their content on all three
+  message paths** instead of coming through as `[interactive message]`.
+  When Lark pushes or returns a card it transforms it and drops the
+  markdown body from the top-level fields — the rendered form left in
+  `elements[]` is often just an image. `extractInteractiveText` now also
+  reads the original card preserved under `user_dsl` (a JSON string of
+  `{ body: { elements: [...] }, schema }`), which is the only source
+  available on the inbound webhook push (it has no API call to attach a
+  parameter to). The element-walking logic is factored into a shared
+  `walkSchema2Elements` helper, and diagnostic logging is restored for
+  unrecognized card schemas (#87).
+
+### Added
+- **`card_msg_content_type: 'user_card_content'` on the history
+  (`listMessages`) and quoted (`fetchQuotedMessage`) fetch paths.** The
+  API then returns cards as resolved `body.elements[...]`, which the same
+  `extractInteractiveText` reads without parsing raw card DSL. Combined
+  with the inbound `user_dsl` fix, all three card paths — inbound push,
+  history context, and quoted reply — now extract content correctly (#87).
+
 ## [0.3.1] - 2026-05-27
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **`card_msg_content_type: 'user_card_content'` on the history
-  (`listMessages`) and quoted (`fetchQuotedMessage`) fetch paths.** The
-  API then returns cards as resolved `body.elements[...]`, which the same
-  `extractInteractiveText` reads without parsing raw card DSL. Combined
+  (`listMessages`) and quoted (`fetchQuotedMessage`) fetch paths.** This asks
+  the API to return the **original card JSON** (the Schema 2.0 card as sent,
+  with `body.elements[...]`) rather than the transformed/rendered form, whose
+  top-level `elements[]` drops the markdown body. The API does not resolve the
+  card to plain text — it returns the original card JSON, which carries
+  `body.elements` that the same `extractInteractiveText` then reads. Combined
   with the inbound `user_dsl` fix, all three card paths — inbound push,
   history context, and quoted reply — now extract content correctly (#87).
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lark
-version: 0.3.1
+version: 0.3.2
 description: >-
   Lark (international) and Feishu (飞书, China) communication channel.
   Use when: (1) replying to Lark/Feishu messages (DM or group @mentions),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zylos-lark",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zylos-lark",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "1.59.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos-lark",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Lark and Feishu communication channel",
   "type": "module",
   "main": "src/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -808,8 +808,12 @@ async function fetchQuotedMessage(messageId) {
     const client = getClient();
     const res = await client.im.message.get({
       path: { message_id: messageId },
-      // Resolve interactive cards to user-facing content (body.elements[...])
-      // so extractInteractiveText reads quoted cards without parsing card DSL.
+      // Request the ORIGINAL card JSON for interactive cards (the Schema 2.0
+      // card as sent, with `body.elements[...]`). Without this param the API
+      // returns the transformed/rendered form whose top-level `elements[]` has
+      // dropped the markdown body; with it, extractInteractiveText can read
+      // body.elements directly. (The API does NOT resolve cards to plain text —
+      // it returns the original card JSON, which happens to carry body.elements.)
       params: { card_msg_content_type: 'user_card_content' },
     });
     if (res.code === 0 && res.data?.items?.[0]) {

--- a/src/index.js
+++ b/src/index.js
@@ -968,29 +968,57 @@ function extractInteractiveText(content) {
   try {
     const parts = [];
 
-    // Schema 2.0 cards (original, before API transformation): body.elements[]
-    const bodyElements = content?.body?.elements || [];
-    for (const el of bodyElements) {
-      if (el.tag === 'markdown' && el.content) {
-        parts.push(el.content);
-      } else if (el.tag === 'div' && el.text?.content) {
-        parts.push(el.text.content);
-      } else if (el.tag === 'plain_text' && el.content) {
-        parts.push(el.content);
-      }
-      // Nested columns (column_set → columns → elements)
-      if (el.tag === 'column_set' && el.columns) {
-        for (const col of el.columns) {
-          for (const nested of (col.elements || [])) {
-            if (nested.tag === 'markdown' && nested.content) {
-              parts.push(nested.content);
-            } else if (nested.tag === 'div' && nested.text?.content) {
-              parts.push(nested.text.content);
+    // Walk a Schema 2.0 `elements[]` array, pushing text content into `parts`.
+    // Handles markdown / div / plain_text, plus column_set → columns → elements.
+    const walkSchema2Elements = (elements) => {
+      for (const el of (elements || [])) {
+        if (el.tag === 'markdown' && el.content) {
+          parts.push(el.content);
+        } else if (el.tag === 'div' && el.text?.content) {
+          parts.push(el.text.content);
+        } else if (el.tag === 'plain_text' && el.content) {
+          parts.push(el.content);
+        }
+        // Nested columns (column_set → columns → elements)
+        if (el.tag === 'column_set' && el.columns) {
+          for (const col of el.columns) {
+            for (const nested of (col.elements || [])) {
+              if (nested.tag === 'markdown' && nested.content) {
+                parts.push(nested.content);
+              } else if (nested.tag === 'div' && nested.text?.content) {
+                parts.push(nested.text.content);
+              } else if (nested.tag === 'plain_text' && nested.content) {
+                parts.push(nested.content);
+              }
             }
           }
         }
       }
+    };
+
+    // Schema 2.0 read-back: when Lark reads/pushes a card back, it transforms it
+    // and drops the markdown body from the top-level fields — only the RENDERED
+    // form survives in `elements[]` (often just an image), which is why a real
+    // markdown card otherwise falls through to the `[interactive message]`
+    // placeholder. The ORIGINAL card (with the markdown content) is preserved
+    // under `user_dsl`: a JSON string of `{ body: { elements: [...] }, schema }`.
+    // Prefer it when present so inbound markdown cards read correctly.
+    if (content?.user_dsl) {
+      try {
+        const dsl = typeof content.user_dsl === 'string'
+          ? JSON.parse(content.user_dsl)
+          : content.user_dsl;
+        walkSchema2Elements(dsl?.body?.elements);
+        const dslMeaningful = parts.map(p => p.trim()).filter(Boolean);
+        if (dslMeaningful.length > 0) return dslMeaningful.join('\n');
+        parts.length = 0; // nothing usable in user_dsl — reset and try other strategies
+      } catch {
+        // Malformed user_dsl — fall through to the other strategies below.
+      }
     }
+
+    // Schema 2.0 cards (original, before API transformation): body.elements[]
+    walkSchema2Elements(content?.body?.elements);
     if (parts.length > 0) return parts.join('\n');
 
     // Legacy / API-transformed format: elements[] at top level (2D array)
@@ -1018,9 +1046,18 @@ function extractInteractiveText(content) {
     // original cards have header.title.content
     const title = content?.title || content?.header?.title?.content;
     if (title) return `[card] ${title}`;
-  } catch {
-    // Fall through
+  } catch (err) {
+    // Log a truncated preview so a parse-throwing card schema can be diagnosed.
+    try {
+      console.log(`[lark] extractInteractiveText threw (${err.message}); content preview: ${JSON.stringify(content).slice(0, 2000)}`);
+    } catch { /* unable to stringify */ }
+    return '[interactive message]';
   }
+  // No strategy matched — log a preview so the unhandled card schema can be
+  // identified and supported in a follow-up (mirrors the intent of PR #76).
+  try {
+    console.log(`[lark] extractInteractiveText: unrecognized card schema, content preview: ${JSON.stringify(content).slice(0, 2000)}`);
+  } catch { /* unable to stringify */ }
   return '[interactive message]';
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -808,6 +808,9 @@ async function fetchQuotedMessage(messageId) {
     const client = getClient();
     const res = await client.im.message.get({
       path: { message_id: messageId },
+      // Resolve interactive cards to user-facing content (body.elements[...])
+      // so extractInteractiveText reads quoted cards without parsing card DSL.
+      params: { card_msg_content_type: 'user_card_content' },
     });
     if (res.code === 0 && res.data?.items?.[0]) {
       const msg = res.data.items[0];

--- a/src/lib/message.js
+++ b/src/lib/message.js
@@ -148,6 +148,10 @@ export async function listMessages(chatId, limit = 20, sortType = 'desc', startT
       page_size: Math.min(limit, 50),
       sort_type: sortType === 'asc' ? 'ByCreateTimeAsc' : 'ByCreateTimeDesc',
       user_id_type: 'open_id',
+      // Ask the API to return interactive cards as resolved user-facing content
+      // (body.elements[...]) so extractInteractiveText reads them without
+      // parsing raw card DSL. Mirrors the fix on the inbound/quoted paths.
+      card_msg_content_type: 'user_card_content',
     };
 
     if (startTime) params.start_time = String(startTime);

--- a/src/lib/message.js
+++ b/src/lib/message.js
@@ -148,9 +148,11 @@ export async function listMessages(chatId, limit = 20, sortType = 'desc', startT
       page_size: Math.min(limit, 50),
       sort_type: sortType === 'asc' ? 'ByCreateTimeAsc' : 'ByCreateTimeDesc',
       user_id_type: 'open_id',
-      // Ask the API to return interactive cards as resolved user-facing content
-      // (body.elements[...]) so extractInteractiveText reads them without
-      // parsing raw card DSL. Mirrors the fix on the inbound/quoted paths.
+      // Request the ORIGINAL card JSON for interactive cards (Schema 2.0 card
+      // as sent, with `body.elements[...]`) instead of the transformed/rendered
+      // form, whose top-level `elements[]` drops the markdown body. The API does
+      // NOT resolve cards to plain text — it returns the original card JSON,
+      // which carries body.elements that extractInteractiveText then reads.
       card_msg_content_type: 'user_card_content',
     };
 


### PR DESCRIPTION
## Problem
Inbound Schema 2.0 **markdown cards** are delivered to the agent as the placeholder `[interactive message]` — the bot can't read the text.

When Lark reads/pushes a card back, it transforms it and **drops the markdown body from the top-level fields**; only the rendered form (often just an `img`) survives in `elements[]`, so `extractInteractiveText` finds no text and falls through to the placeholder.

## Root cause (verified empirically)
The original card — including the markdown — **is** present in the inbound event, under `content.user_dsl` (a JSON string of `{ body: { elements: [...] }, schema: "2.0" }`). We just weren't reading it.

Captured a real inbound markdown card; its `user_dsl.body.elements[0]` was `{ tag: "markdown", content: "# …full markdown…" }`.

## Fix
`extractInteractiveText` now:
1. **Parses `content.user_dsl` first** (highest priority — it's the authoritative original), reusing a shared Schema 2.0 element walker (markdown / div / plain_text + `column_set` nesting). Returns the markdown when present.
2. Falls back to the existing strategies unchanged: top-level `body.elements` → legacy 2D `elements[]` → title fallback → placeholder.
3. Logs a truncated content preview when nothing matches or a parse throws, so future unhandled card schemas are easy to identify (folds in the diagnostic intent of #76).

## Verification
Ran the updated function against the **real captured payload**: heading, bold, list, inline code, quote, and link all recovered (no longer the placeholder). Regression-checked legacy 2D cards, original `body.elements`, title fallback, and the empty→placeholder path — all unchanged. `node --check` clean.

## Notes
- Supersedes the need for #76 (logging-only) for this case, and is the inbound fix that #84 doesn't provide (#84 doesn't modify `extractInteractiveText`).
- Code-only; version bump + CHANGELOG can follow as a separate release PR.