### PR TITLE
fix: group context sort + quoted file info (#89)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.4] - 2026-06-29
+
+### Fixed
+- **Group context chronological sort**: `logMessage` now normalizes bare
+  epoch-millis timestamps (from `event.header.create_time`) to ISO 8601
+  before storing. Previously `Date.parse("1782657780678")` returned `NaN`,
+  causing all real-time inbound messages to collapse to sort key `0` and
+  get trimmed by `slice(-count)`, leaving the context window dominated by
+  bot replies and stale lazy-loaded entries (#89).
+- **Quoted message file/image/audio metadata**: `fetchQuotedMessage` now
+  handles `file`, `image`, and `audio` message types with full metadata
+  (`file_key`, `file_name`, `image_key`, `msg_id`) instead of falling
+  through to `[file message]` / `[image message]` / `[audio message]` (#89).
+
+### Added
+- **Media (video) and sticker support**: both `extractMessageContent`
+  (inbound path) and `fetchQuotedMessage` (quoted message path) now handle
+  `media` and `sticker` message types, outputting structured metadata
+  instead of generic `[media message]` / `[sticker message]`.
+- **SKILL.md module index**: added `lark-note` (meeting notes / 纪要) and
+  `lark-apps` (Miaoda/Spark app development) to the module index table.
+  Updated module count from 25 to 27 to match `EXPECTED_SUB_SKILLS`.
+
 ## [0.3.3] - 2026-06-28
 
 ### Changed

--- a/SKILL.md
+++ b/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   (2) sending proactive messages or media (images, files) to Lark/Feishu users or groups,
   (3) managing DM access control (dmPolicy: open/allowlist/owner, dmAllowFrom list),
   (4) managing group access control (groupPolicy, per-group allowFrom, smart/mention modes),
-  (5) operating Feishu/Lark productivity surfaces via the bundled lark-cli — documents, sheets, slides, multidim Base, calendar, tasks, mail, drive, wiki/whiteboard, OKR, approval, attendance, video conferencing, minutes, native OpenAPI explorer (see "Bundled Capability Modules" section in SKILL.md body — full module index under references/),
+  (5) operating Feishu/Lark productivity surfaces via the bundled lark-cli — documents, sheets, slides, multidim Base, calendar, tasks, mail, drive, wiki/whiteboard, OKR, approval, attendance, video conferencing, minutes, meeting notes (纪要), Miaoda/Spark apps, native OpenAPI explorer (see "Bundled Capability Modules" section in SKILL.md body — full module index under references/),
   (6) configuring the bot (admin CLI, markdown card settings, verification token, encrypt key),
   (7) troubleshooting Lark webhook or service issues.
   Config at ~/zylos/components/lark/config.json. Service: pm2 zylos-lark.
@@ -62,13 +62,13 @@ Depends on: comm-bridge (C4 message routing).
 
 ## Bundled Capability Modules (lark-cli)
 
-This skill bundles **25 capability modules** under `references/`, each operating against Feishu/Lark via the `lark-cli` binary. **They are not auto-loaded as top-level skills** — Claude Code's skill discovery only scans top-level directories, and these sub-modules live inside this skill. The parent `SKILL.md` (this file) is the entry point.
+This skill bundles **27 capability modules** under `references/`, each operating against Feishu/Lark via the `lark-cli` binary. **They are not auto-loaded as top-level skills** — Claude Code's skill discovery only scans top-level directories, and these sub-modules live inside this skill. The parent `SKILL.md` (this file) is the entry point.
 
 **How to use a module**: when a user's request maps to one of the modules below, `Read` that module's `SKILL.md` first to learn its exact commands/flags, then invoke `lark-cli <module> ...`.
 
 **Prerequisites** (installed automatically by `zylos add lark` / `zylos upgrade lark` — see `hooks/post-install-shared.js`):
 - `lark-cli` binary on PATH (`npm install -g @larksuite/cli`).
-- 25 sub-skill folders under `references/lark-*/` (`npx xc-skills add larksuite/cli`).
+- 27 sub-skill folders under `references/lark-*/` (`npx xc-skills add larksuite/cli`).
 - App credentials in lark-cli's keychain (`~/.lark-cli/config.json` + AES-256-GCM encrypted file under `~/.local/share/lark-cli/`); pushed from `~/zylos/.env` automatically.
 
 **Identity (`--as bot` vs `--as user`)**:
@@ -117,6 +117,12 @@ Path prefix for all entries: `references/`
 | `lark-vc/SKILL.md` | Video conferencing history, meeting summaries (notes/todos/chapters/transcripts), participant snapshots |
 | `lark-vc-agent/SKILL.md` | Have the bot join/leave a live meeting on the user's behalf; consume real-time events |
 | `lark-minutes/SKILL.md` | Minutes: list, basic info, transcripts, AI summaries |
+| `lark-note/SKILL.md` | Meeting notes (纪要): query note detail by note_id, get note_doc_token / verbatim_doc_token, read unified transcripts |
+
+#### Apps & low-code
+| Module | Use when… |
+|---|---|
+| `lark-apps/SKILL.md` | Miaoda/Spark apps: create, publish HTML sites, local full-stack dev, cloud-based generation, DB ops, release management |
 
 #### Workflows & platform
 | Module | Use when… |

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lark
-version: 0.3.3
+version: 0.3.4
 description: >-
   Lark (international) and Feishu (飞书, China) communication channel.
   Use when: (1) replying to Lark/Feishu messages (DM or group @mentions),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zylos-lark",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zylos-lark",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "MIT",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "1.59.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos-lark",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Lark and Feishu communication channel",
   "type": "module",
   "main": "src/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -562,8 +562,12 @@ function decrypt(encrypt, encryptKey) {
 async function logMessage(chatType, chatId, userId, openId, text, messageId, timestamp, mentions, threadId = null) {
   const userName = await resolveUserName(userId);
   const resolvedText = resolveMentions(text, mentions);
+  let normalizedTs = timestamp || new Date().toISOString();
+  if (/^\d+$/.test(normalizedTs)) {
+    normalizedTs = new Date(parseInt(normalizedTs, 10)).toISOString();
+  }
   const logEntry = {
-    timestamp: timestamp || new Date().toISOString(),
+    timestamp: normalizedTs,
     message_id: messageId,
     user_id: userId,
     open_id: openId,
@@ -828,6 +832,12 @@ async function fetchQuotedMessage(messageId) {
         ({ text } = extractPostText(JSON.parse(msg.body?.content || '{}').content || [], messageId));
       } else if (msg.msg_type === 'interactive') {
         text = extractInteractiveText(content);
+      } else if (msg.msg_type === 'file') {
+        text = `[file: ${content.file_name || 'unknown'}, file_key: ${content.file_key}, msg_id: ${messageId}]`;
+      } else if (msg.msg_type === 'image') {
+        text = `[image, image_key: ${content.image_key}, msg_id: ${messageId}]`;
+      } else if (msg.msg_type === 'audio') {
+        text = `[audio, file_key: ${content.file_key}, msg_id: ${messageId}]`;
       } else {
         text = `[${msg.msg_type} message]`;
       }

--- a/src/index.js
+++ b/src/index.js
@@ -838,6 +838,10 @@ async function fetchQuotedMessage(messageId) {
         text = `[image, image_key: ${content.image_key}, msg_id: ${messageId}]`;
       } else if (msg.msg_type === 'audio') {
         text = `[audio, file_key: ${content.file_key}, msg_id: ${messageId}]`;
+      } else if (msg.msg_type === 'media') {
+        text = `[media: ${content.file_name || 'video'}, file_key: ${content.file_key}, msg_id: ${messageId}]`;
+      } else if (msg.msg_type === 'sticker') {
+        text = `[sticker, file_key: ${content.file_key || 'unknown'}]`;
       } else {
         text = `[${msg.msg_type} message]`;
       }
@@ -1107,6 +1111,10 @@ function extractMessageContent(message) {
       return { text: '', imageKeys: [], fileKey: content.file_key, fileName: content.file_name || 'unknown', audioKey: null };
     case 'audio':
       return { text: '', imageKeys: [], fileKey: null, fileName: null, audioKey: content.file_key || null };
+    case 'media':
+      return { text: `[media: ${content.file_name || 'video'}, file_key: ${content.file_key || 'unknown'}, msg_id: ${message.message_id}]`, imageKeys: [], fileKey: null, fileName: null, audioKey: null };
+    case 'sticker':
+      return { text: `[sticker, file_key: ${content.file_key || 'unknown'}]`, imageKeys: [], fileKey: null, fileName: null, audioKey: null };
     case 'interactive':
       return { text: extractInteractiveText(content), imageKeys: [], fileKey: null, fileName: null, audioKey: null };
     default:


### PR DESCRIPTION
## Summary

Fixes two bugs in group `@mention` handling that caused the agent to receive wrong/stale `<group-context>` and lose file metadata in `<replying-to>` blocks.

- **Timestamp normalization**: `logMessage` now converts bare epoch-millis strings (from `event.header.create_time`) to ISO 8601 before storing. Previously `Date.parse("1782657780678")` returned `NaN`, causing all real-time inbound messages to sort-collapse to key `0` and get trimmed by `slice(-count)`.
- **Quoted message file info**: `fetchQuotedMessage` now handles `file`, `image`, and `audio` message types with full metadata (`file_key`, `file_name`, `image_key`, `msg_id`) instead of falling through to `[file message]`. Format matches the inbound path (similar approach to coco-workspace's quoted attachment handling in PR #86/#88).

Closes #89

## Test plan

- [x] All 20 existing tests pass
- [ ] Deploy and send a file message in a group, then reply to it with `@bot` — verify `<replying-to>` contains file_key and file_name
- [ ] Verify `<group-context>` shows chronologically correct recent messages (not dominated by bot replies)
- [ ] Test with image and audio quoted messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)