### PR TITLE
fix: use named profile (--name lark) for lark-cli config init

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -140,7 +140,9 @@ Before running `lark-cli <module> <subcmd>`:
 
 1. Read `references/<module>/SKILL.md` to confirm exact subcommands, flags, and required vs. optional args.
 2. If that module's `SKILL.md` references additional docs under its own `references/` subdirectory, read those as well.
-3. Run the command.
+3. Run the command with `--profile lark`: `lark-cli --profile lark <module> <subcmd> ...`
+
+The `--profile lark` flag selects this component's credentials. Always include it — without it, lark-cli uses whichever profile is active, which may belong to zylos-feishu if both are installed. The `runLarkCli()` bridge in `src/lib/lark-cli-bridge.js` injects this flag automatically.
 
 Skipping step 1 risks calling wrong subcommand names or missing required flags — `lark-cli` is feature-rich and each module covers dozens of subcommands.
 

--- a/hooks/post-install-shared.js
+++ b/hooks/post-install-shared.js
@@ -272,6 +272,7 @@ export function syncCredentialsToLarkCli(opts = {}) {
     '--app-id', appId,
     '--app-secret-stdin',
     '--brand', LARK_BRAND,
+    '--name', LARK_BRAND,
     '--lang', lang,
   ], {
     input: appSecret + '\n',

--- a/src/lib/lark-cli-bridge.js
+++ b/src/lib/lark-cli-bridge.js
@@ -26,6 +26,7 @@ import { sendToUser } from './message.js';
 import { getConfig } from './config.js';
 
 const AUTH_REQUIRED_TYPE_REGEX = /_user_login_required$/;
+const PROFILE_NAME = 'lark';
 
 /**
  * Thrown when `lark-cli` returns an error that indicates the current
@@ -55,8 +56,9 @@ export function runLarkCli(args, opts = {}) {
   if (!Array.isArray(args)) {
     throw new TypeError('runLarkCli: args must be an array of strings');
   }
+  const fullArgs = ['--profile', PROFILE_NAME, ...args];
   try {
-    return execFileSync('lark-cli', args, {
+    return execFileSync('lark-cli', fullArgs, {
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'pipe'],
       ...opts,


### PR DESCRIPTION
## Summary
- Add `--name lark` to `lark-cli config init` in `syncCredentialsToLarkCli()`
- Prevents credential overwrite when zylos-feishu is also installed on the same machine
- Each component gets its own named profile in lark-cli's `apps` array

## Context
Companion PR to zylos-feishu#31 which adds `--name feishu`. Without named profiles, whichever component runs `config init` last overwrites the other's credentials.

## Test plan
- [x] `node --test` passes
- [ ] Verify `~/.lark-cli/config.json` retains both profiles after install/upgrade of both components

🤖 Generated with [Claude Code](https://claude.com/claude-code)