### PR TITLE
fix: uploadFile + open_id fallback + media docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.5] - 2026-07-04
+
+### Fixed
+- **File upload**: `uploadFile()` now uses `createReadStream` instead of
+  `readFileSync` — the SDK's form-data needs a stream for proper
+  filename/content-type. Fixes `"Failed to upload file: undefined"` for
+  .docx, .pptx, and other file types.
+- **File type inference**: `inferFileType()` maps extensions (`.pptx`→`ppt`,
+  `.docx`→`doc`, `.xlsx`→`xls`, etc.) instead of hardcoding `'stream'`.
+- **SDK response parsing**: handle both `{file_key}` and `{data: {file_key}}`
+  shapes for compatibility with newer SDK versions.
+
+### Changed
+- SKILL.md description trimmed under 1024 chars (1000→941)
+- Added `[MEDIA:...]` must-be-only-content constraint to SKILL.md
+
 ## [0.3.4] - 2026-06-29
 
 ### Fixed

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lark
-version: 0.3.4
+version: 0.3.5
 description: >-
   Lark (international) and Feishu (飞书, China) communication channel.
   Use when: (1) replying to Lark/Feishu messages (DM or group @mentions),

--- a/SKILL.md
+++ b/SKILL.md
@@ -7,8 +7,11 @@ description: >-
   (2) sending proactive messages or media (images, files) to Lark/Feishu users or groups,
   (3) managing DM access control (dmPolicy: open/allowlist/owner, dmAllowFrom list),
   (4) managing group access control (groupPolicy, per-group allowFrom, smart/mention modes),
-  (5) operating Feishu/Lark productivity surfaces via the bundled lark-cli — documents, sheets, slides, multidim Base, calendar, tasks, mail, drive, wiki/whiteboard, OKR, approval, attendance, video conferencing, minutes, meeting notes (纪要), Miaoda/Spark apps, native OpenAPI explorer (see "Bundled Capability Modules" section in SKILL.md body — full module index under references/),
-  (6) configuring the bot (admin CLI, markdown card settings, verification token, encrypt key),
+  (5) operating Lark productivity surfaces via the bundled lark-cli — documents, sheets, slides,
+  multidim Base, calendar, tasks, mail, drive, wiki, OKR, approval, attendance,
+  video conferencing, minutes, Miaoda/Spark apps, native OpenAPI explorer
+  (see "Bundled Capability Modules" in SKILL.md body — full module index under references/),
+  (6) configuring the bot (admin CLI, markdown card settings, verification token),
   (7) troubleshooting Lark webhook or service issues.
   Config at ~/zylos/components/lark/config.json. Service: pm2 zylos-lark.
 type: communication
@@ -162,6 +165,8 @@ cat <<'EOF' | node ~/zylos/.claude/skills/comm-bridge/scripts/c4-send.js "lark" 
 [MEDIA:file]/path/to/file.pdf
 EOF
 ```
+
+> ⚠️ `[MEDIA:...]` must be the only content in the message. Send text and media as separate calls.
 
 Direct send (bypasses C4 logging, for testing only):
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zylos-lark",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zylos-lark",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "MIT",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "1.59.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos-lark",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Lark and Feishu communication channel",
   "type": "module",
   "main": "src/index.js",

--- a/src/lib/message.js
+++ b/src/lib/message.js
@@ -338,28 +338,38 @@ export async function downloadAudio(messageId, fileKey, savePath) {
   }
 }
 
+function inferFileType(ext) {
+  const map = {
+    '.opus': 'opus', '.mp4': 'mp4', '.pdf': 'pdf',
+    '.doc': 'doc', '.docx': 'doc',
+    '.xls': 'xls', '.xlsx': 'xls',
+    '.ppt': 'ppt', '.pptx': 'ppt',
+  };
+  return map[(ext || '').toLowerCase()] || 'stream';
+}
+
 /**
  * Upload file to Lark
  */
-export async function uploadFile(filePath, fileType = 'stream') {
+export async function uploadFile(filePath, fileType) {
   const client = getClient();
 
   try {
-    const fileData = fs.readFileSync(filePath);
-    const fileName = path.basename(filePath);
+    if (!fileType) fileType = inferFileType(path.extname(filePath));
 
     const res = await client.im.file.create({
       data: {
         file_type: fileType,
-        file_name: fileName,
-        file: fileData,
+        file_name: path.basename(filePath),
+        file: fs.createReadStream(filePath),
       },
     });
 
-    if (res.code === 0) {
-      return { success: true, fileKey: res.data.file_key, message: 'File uploaded successfully' };
+    const fileKey = res.file_key ?? res.data?.file_key;
+    if (fileKey) {
+      return { success: true, fileKey, message: 'File uploaded successfully' };
     } else {
-      return { success: false, message: `Failed to upload file: ${res.msg}`, code: res.code };
+      return { success: false, message: `Failed to upload file: ${res.msg ?? JSON.stringify(res)}`, code: res.code };
     }
   } catch (err) {
     return { success: false, message: err.message };


### PR DESCRIPTION
## Summary

- **Fix file upload**: `uploadFile()` now uses `createReadStream` instead of `readFileSync` (Buffer) — the SDK's form-data needs a stream for proper filename/content-type. Response parsing handles both `{file_key}` and `{data: {file_key}}` shapes.
- **Extension-based file type inference**: `inferFileType()` maps `.pptx`→`ppt`, `.docx`→`doc`, `.xlsx`→`xls`, etc. instead of hardcoding `'stream'`
- **SKILL.md**: Trimmed description under 1024 chars (1000→941) + added `[MEDIA:...]` must-be-only-content constraint

Same uploadFile fix as zylos-feishu v0.3.1.

## Test plan

- [x] npm test: 20/20 pass
- [x] Identical fix verified on zylos-feishu: pdf, txt, svg, pptx all upload successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)